### PR TITLE
Fixes #2: Remove deprecated function obs_frontend_add_dock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,10 +16,9 @@ namespace
 
 void obs_module_post_load(void)
 {
-  auto mainWindow = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-  pluginInstance = new ReplayBufferPro::Plugin(mainWindow);
+  pluginInstance = new ReplayBufferPro::Plugin();
 
-  obs_frontend_add_dock(pluginInstance);
+  obs_frontend_add_dock_by_id("replay-buffer-pro", "Replay Buffer Pro", pluginInstance);
 }
 
 bool obs_module_load(void)

--- a/src/plugin/plugin.hpp
+++ b/src/plugin/plugin.hpp
@@ -24,14 +24,12 @@
 #include <obs-frontend-api.h> // Frontend API functions
 
 // Qt includes
-#include <QDockWidget>
-#include <QMainWindow>
+#include <QWidget>
 #include <QTimer>
 
 // Local includes
 #include "ui/ui-components.hpp"
 #include "managers/settings-manager.hpp"
-#include "managers/dock-state-manager.hpp"
 #include "managers/replay-buffer-manager.hpp"
 #include "managers/hotkey-manager.hpp"
 
@@ -47,7 +45,7 @@ namespace ReplayBufferPro
    * - Automatic UI state management based on buffer status
    * - Persistent dock position and settings
    */
-  class Plugin : public QDockWidget
+  class Plugin : public QWidget
   {
     Q_OBJECT
 
@@ -67,18 +65,6 @@ namespace ReplayBufferPro
      * - Sets up settings monitoring timer
      */
     explicit Plugin(QWidget *parent = nullptr);
-
-    /**
-     * @brief Creates and docks widget to OBS main window
-     * @param mainWindow The OBS main window to dock to
-     * 
-     * Creates a widget docked to the OBS main window.
-     * In addition to standalone widget initialization:
-     * - Creates dock state manager
-     * - Restores previous dock position and state
-     * - Sets up dock state persistence
-     */
-    explicit Plugin(QMainWindow *mainWindow);
 
     /**
      * @brief Cleans up resources and removes OBS event callbacks
@@ -152,7 +138,6 @@ namespace ReplayBufferPro
     //=========================================================================
     UIComponents *ui;                   ///< UI components
     SettingsManager *settingsManager;   ///< Settings manager
-    DockStateManager *dockStateManager; ///< Dock state manager
     ReplayBufferManager *replayManager; ///< Replay buffer manager
     HotkeyManager *hotkeyManager;       ///< Hotkey manager
     QTimer *settingsMonitorTimer;       ///< Timer for monitoring OBS settings changes

--- a/src/ui/ui-components.cpp
+++ b/src/ui/ui-components.cpp
@@ -294,6 +294,14 @@ namespace ReplayBufferPro
       onValueChanged = callback;
   }
 
+  void TickLabelWidget::showEvent(QShowEvent* event) {
+      QWidget::showEvent(event);
+      QTimer::singleShot(0, this, [this]() {
+          updateVisibleTicks();
+          updateTickPositions();
+      });
+  }
+
   void TickLabelWidget::updateVisibleTicks() {
       const int totalWidth = width();
       const int minSpaceBetweenLabels = 50; // Minimum pixels between labels

--- a/src/ui/ui-components.hpp
+++ b/src/ui/ui-components.hpp
@@ -43,6 +43,7 @@ namespace ReplayBufferPro
   protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 
   private:
     void updateVisibleTicks();


### PR DESCRIPTION
`fix` Issue #2 - Remove deprecated function `obs_frontend_add_dock` (function removed in OBS 32.0.x)
`chore`  Replace `obs_frontend_add_dock` with `obs_frontend_add_dock_by_id` and convert widget to `QWidget` instead of `QDockWidget`
`chore` Force slider labels to reflow upon dock widget init