### PR TITLE
fix/corrupted-frames

### DIFF
--- a/src/utils/logger.hpp
+++ b/src/utils/logger.hpp
@@ -28,6 +28,21 @@ namespace ReplayBufferPro
     }
 
     /**
+     * @brief Log warning message
+     * @param format Format string
+     * @param ... Format arguments
+     */
+    static void warning(const char *format, ...)
+    {
+      va_list args;
+      va_start(args, format);
+      char buf[4096];
+      vsnprintf(buf, sizeof(buf), format, args);
+      blog(LOG_WARNING, "[ReplayBufferPro] %s", buf);
+      va_end(args);
+    }
+
+    /**
      * @brief Log error message
      * @param format Format string
      * @param ... Format arguments


### PR DESCRIPTION
This resolves the issue where the first few frames of trimmed clips would appear corrupted while audio continued normally. The corruption was caused by starting video streams from non-keyframes (P/B-frames) which lack necessary reference frames for proper decoding.