### PR TITLE
docs: align website troubleshooting/HowTo schema with install path

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -188,7 +188,7 @@
             "@type": "HowToStep",
             "position": 4,
             "name": "Verify Installation",
-            "text": "Verify the final installation structure: replay-buffer-pro.dll in obs-plugins/64bit/, and data files in data/obs-plugins/replay-buffer-pro/ including locale files."
+            "text": "Verify the final installation structure: replay-buffer-pro.dll in plugins/replay-buffer-pro/bin/64bit/, and data files in plugins/replay-buffer-pro/data/locale/."
           }
         ]
       }
@@ -721,7 +721,7 @@
               </div>
               <div class="troubleshoot-content">
                 <strong>Plugin Not Loading</strong>
-                <p>Ensure <code>replay-buffer-pro.dll</code> is in <code>obs-studio/obs-plugins/64bit/</code>. Restart OBS Studio after placing the file.</p>
+                <p>Ensure <code>replay-buffer-pro.dll</code> is in <code>%ALLUSERSPROFILE%\obs-studio\plugins\replay-buffer-pro\bin\64bit\</code> (typically <code>C:\ProgramData\obs-studio\plugins\replay-buffer-pro\bin\64bit\</code>). Restart OBS Studio after placing the file.</p>
               </div>
             </div>
             


### PR DESCRIPTION
## Summary

- The Installation sections of `README.md` and `docs/index.html` were migrated to the new `%ALLUSERSPROFILE%/obs-studio/plugins/<plugin-name>/bin/64bit/` layout in b7bd8be, but two stale references in `docs/index.html` still pointed at the old `obs-plugins/64bit/` structure, contradicting the Installation tree shown right above them.
- Updates the HowTo JSON-LD schema's "Verify Installation" step and the Troubleshooting "Plugin Not Loading" card to use the new layout — matches the OBS ProgramData plugin convention (`<plugin-name>/bin/64bit/<plugin-name>.dll` + `<plugin-name>/data/locale/`) and what `cmake --install` actually produces per `cmake/windows/helpers.cmake`.

## Test plan

- [ ] `grep -nE "obs-plugins/64bit|data/obs-plugins/replay-buffer-pro" docs/index.html README.md` returns no matches
- [ ] Open `docs/index.html` and confirm the Troubleshooting "Plugin Not Loading" path matches the Installation tree above it
- [ ] Validate the HowTo JSON-LD block via Google's Rich Results Test (or any JSON parser) to confirm the edit didn't break the schema