### PR TITLE
chore(cmake): align prepare_release ZIP layout with OBS plugin convention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,8 +105,8 @@ set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_nam
 # Release package configuration (Windows only)
 if(OS_WINDOWS)
   set(RELEASE_DIR "${CMAKE_BINARY_DIR}/release-package/obs-studio")
-  set(RELEASE_PLUGIN_DIR "${RELEASE_DIR}/obs-plugins/64bit")
-  set(RELEASE_DATA_DIR "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}")
+  set(RELEASE_PLUGIN_DIR "${RELEASE_DIR}/plugins/${CMAKE_PROJECT_NAME}/bin/64bit")
+  set(RELEASE_DATA_DIR "${RELEASE_DIR}/plugins/${CMAKE_PROJECT_NAME}/data")
   set(RELEASE_ZIP_DIR "${CMAKE_BINARY_DIR}/releases/${PROJECT_VERSION}")
   set(RELEASE_ZIP "${RELEASE_ZIP_DIR}/${CMAKE_PROJECT_NAME}-windows-x64.zip")
 


### PR DESCRIPTION
## Summary

- The `prepare_release` custom target in `CMakeLists.txt:107-109` was producing a Windows release ZIP using the old `obs-plugins/64bit/` + `data/obs-plugins/<plugin>/` layout.
- This conflicts with what `cmake --install` actually emits (per `cmake/windows/helpers.cmake:25,78`) and with what the CI release pipeline (`Package-Windows.ps1`) ships in the GitHub release ZIPs.
- After this change, a local `cmake --build --target prepare_release` produces the same `plugins/<plugin-name>/bin/64bit/` + `plugins/<plugin-name>/data/` structure described in the README and website Installation sections.

Companion to #18 (docs alignment).

## Test plan

- [ ] On a Windows machine: `cmake --preset windows-x64 && cmake --build build_x64 --config RelWithDebInfo --target prepare_release`
- [ ] Inspect `build_x64/release-package/obs-studio/` — should contain `plugins/replay-buffer-pro/bin/64bit/replay-buffer-pro.dll` and `plugins/replay-buffer-pro/data/locale/en-US.ini`
- [ ] Unzip `build_x64/releases/<version>/replay-buffer-pro-windows-x64.zip` and confirm the same structure
- [ ] Extract the ZIP into `%ALLUSERSPROFILE%\` and verify OBS Studio loads the plugin