### PR TITLE
Website: fix versioned download links + add macOS download

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@
           "price": "0",
           "priceCurrency": "USD"
         },
-        "downloadUrl": "https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip",
+        "downloadUrl": "https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest",
         "softwareRequirements": "OBS Studio 30.0.0+",
         "keywords": "OBS Studio, plugin, replay buffer, streaming, recording, clip, gaming, instant replay",
         "screenshot": "https://raw.githubusercontent.com/JoshuaPotter/replay-buffer-pro/main/screenshot.png"
@@ -169,7 +169,7 @@
             "position": 1,
             "name": "Download Plugin",
             "text": "Download the latest release of Replay Buffer Pro from the link above.",
-            "url": "https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip"
+            "url": "https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest"
           },
           {
             "@type": "HowToStep",
@@ -182,7 +182,7 @@
             "position": 3,
             "name": "Extract and Copy Files",
             "text": "Extract the ZIP and copy the obs-studio folder to your OBS plugins directory (typically C:\\ProgramData\\obs-studio\\plugins\\).",
-            "url": "https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip"
+            "url": "https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest"
           },
           {
             "@type": "HowToStep",
@@ -204,7 +204,7 @@
         <div class="brand">Replay Buffer Pro</div>
         <nav class="nav">
           <a class="btn btn-ghost" href="https://github.com/JoshuaPotter/replay-buffer-pro" rel="noopener" target="_blank">View on GitHub</a>
-          <a id="download-top" class="btn btn-primary" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip">Download (<span class="release-version" data-prefix"v">v1.4.1</span>)</a>
+          <a id="download-top" class="btn btn-primary" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download (<span class="release-version" data-prefix="v">v1.4.1</span>)</a>
         </nav>
       </div>
     </header>
@@ -221,8 +221,9 @@
             <h1>Replay Buffer Pro</h1>
             <p class="lead">Save the last moments of your stream or recording with one click.</p>
             <div class="cta-row">
-              <a id="download-cta" class="btn btn-primary btn-lg" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip">Download for Windows (x64)</a>
-              <div id="release-meta" class="subtext"><span class="release-version" data-prefix"v">v1.4.1</span> • Requires OBS Studio 30.0.0+</div>
+              <a id="download-cta" class="btn btn-primary btn-lg" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for Windows (x64)</a>
+              <a id="download-cta-macos" class="btn btn-primary btn-lg" data-download="macos" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for macOS</a>
+              <div id="release-meta" class="subtext"><span class="release-version" data-prefix="v">v1.4.1</span> • Requires OBS Studio 30.0.0+</div>
             </div>
           </div>
           <div class="hero-media">
@@ -473,7 +474,8 @@
           <div class="section-header">
             <h2>Installation</h2>
             <div class="section-actions">
-              <a id="download-secondary" class="btn btn-primary" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip">Download for Windows (x64)</a>
+              <a id="download-secondary" class="btn btn-primary" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for Windows (x64)</a>
+              <a id="download-secondary-macos" class="btn btn-primary" data-download="macos" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for macOS</a>
             </div>
           </div>
           
@@ -801,13 +803,13 @@
               <li><a href="https://github.com/JoshuaPotter/replay-buffer-pro/issues" rel="noopener" target="_blank">Report an Issue<svg class="external-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/></svg></a></li>
               <li><a href="https://github.com/JoshuaPotter/replay-buffer-pro/releases" rel="noopener" target="_blank">Releases<svg class="external-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/></svg></a></li>
             </ul>
-            <a href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip" class="footer-download-btn" rel="noopener" target="_blank">
+            <a href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest" class="footer-download-btn" data-download="windows" rel="noopener" target="_blank">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
                 <polyline points="7 10 12 15 17 10"/>
                 <line x1="12" y1="15" x2="12" y2="3"/>
               </svg>
-              Download (<span class="release-version" data-prefix"v">v1.4.1</span>)
+              Download (<span class="release-version" data-prefix="v">v1.4.1</span>)
             </a>
           </div>
         </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -39,7 +39,7 @@ Replay Buffer Pro is a free, open-source plugin for OBS Studio that expands upon
 
 ### Quick Install (Windows)
 
-1. Download the latest release from: https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest/download/replay-buffer-pro-windows-x64.zip
+1. Download the latest release from: https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest (choose `replay-buffer-pro-<version>-windows-x64.zip`)
 2. Close OBS Studio completely
 3. Extract the ZIP file
 4. Copy the `obs-studio` folder to your OBS plugins directory: `%ALLUSERSPROFILE%\obs-studio\plugins\` (typically `C:\ProgramData\obs-studio\plugins\`)

--- a/docs/scripts/index.js
+++ b/docs/scripts/index.js
@@ -1,17 +1,22 @@
 /**
  * Main entry point for the Replay Buffer Pro landing page
  */
-import { fetchLatestReleaseTag, applyReleaseVersionToElements, updateYearByClass } from './utils.js';
+import { fetchLatestRelease, applyReleaseVersionToElements, applyDownloadUrls, updateYearByClass } from './utils.js';
 import { initializePluginSlider } from './plugin-ui-demo.js';
 
 // ES module scripts with defer are guaranteed to run after DOM parsing,
 // so DOMContentLoaded wrapping is unnecessary and can cause missed events.
 initializePluginSlider();
 
-// Fetch and display latest release version
+// Fetch the latest release once, then update the displayed version and point
+// each platform's download buttons at the matching release asset.
 const releaseVersion = document.querySelectorAll('.release-version');
-fetchLatestReleaseTag()
-  .then(tag => applyReleaseVersionToElements(releaseVersion, tag))
+const downloadLinks = document.querySelectorAll('[data-download]');
+fetchLatestRelease()
+  .then(release => {
+    applyReleaseVersionToElements(releaseVersion, release.tag_name);
+    applyDownloadUrls(downloadLinks, release.assets);
+  })
   .catch(error => console.error('Release fetch failed', error));
 
 // Update year in footer

--- a/docs/scripts/utils.js
+++ b/docs/scripts/utils.js
@@ -1,17 +1,36 @@
-export async function fetchLatestReleaseTag(owner = 'JoshuaPotter', repo = 'replay-buffer-pro') {
+export async function fetchLatestRelease(owner = 'JoshuaPotter', repo = 'replay-buffer-pro') {
   const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, {
     headers: { 'Accept': 'application/vnd.github+json' },
   });
   if (!res.ok) throw new Error('Release fetch failed');
-  const data = await res.json();
-  return data.tag_name;
+  return res.json();
 }
 
 export function applyReleaseVersionToElements(elements, tag) {
-  if (!elements) return;
+  if (!elements || !tag) return;
   elements.forEach(el => {
     const prefix = el.dataset.prefix ?? 'v';
     el.textContent = `${prefix}${tag}`;
+  });
+}
+
+// Release asset names are versioned (e.g. replay-buffer-pro-1.5.0-windows-x64.zip),
+// so download links can't be hardcoded. Match each download element's
+// data-download platform to the matching asset and point its href at the
+// real browser_download_url. Elements with no matching asset keep their
+// existing href (the releases page) as a fallback.
+const ASSET_MATCHERS = {
+  windows: /windows.*\.zip$/i,
+  macos: /macos.*\.pkg$/i,
+};
+
+export function applyDownloadUrls(elements, assets = []) {
+  if (!elements) return;
+  elements.forEach(el => {
+    const matcher = ASSET_MATCHERS[el.dataset.download];
+    if (!matcher) return;
+    const asset = assets.find(a => matcher.test(a.name));
+    if (asset) el.href = asset.browser_download_url;
   });
 }
 


### PR DESCRIPTION
Follow-up to the 1.5.0 release cut. Pre-publish website matching checks found the download links would 404 once versioned release artifacts are published.

## Changes
- **`docs/scripts/utils.js` / `index.js`** — fetch the latest release once and set each download button's `href` from the matching asset's `browser_download_url`. Works with the new versioned artifact names (e.g. `replay-buffer-pro-1.5.0-windows-x64.zip`); previously the hardcoded `…/latest/download/replay-buffer-pro-windows-x64.zip` would 404 after publishing 1.5.0.
- **`docs/index.html`** — add macOS (`.pkg`) download buttons alongside Windows; tag all download buttons with `data-download`; fall back to the releases page when an asset isn't found; fix malformed `data-prefix="v"` attributes; point static JSON-LD URLs at the releases page.
- **`docs/llms.txt`** — point the download URL at the releases page.

## Verification
- JS syntax checked; asset-matching unit-tested against the real 1.5.0 asset names (Windows `.zip` → versioned zip, macOS `.pkg` → pkg) and against the pre-publish state (macOS gracefully keeps the releases-page fallback).