### PR TITLE
Website: OS-detecting split download button

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -204,7 +204,7 @@
         <div class="brand">Replay Buffer Pro</div>
         <nav class="nav">
           <a class="btn btn-ghost" href="https://github.com/JoshuaPotter/replay-buffer-pro" rel="noopener" target="_blank">View on GitHub</a>
-          <a id="download-top" class="btn btn-primary" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download (<span class="release-version" data-prefix="v">v1.4.1</span>)</a>
+          <a id="download-top" class="btn btn-primary" data-download-auto data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download (<span class="release-version" data-prefix="v">v1.4.1</span>)</a>
         </nav>
       </div>
     </header>
@@ -221,8 +221,16 @@
             <h1>Replay Buffer Pro</h1>
             <p class="lead">Save the last moments of your stream or recording with one click.</p>
             <div class="cta-row">
-              <a id="download-cta" class="btn btn-primary btn-lg" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for Windows (x64)</a>
-              <a id="download-cta-macos" class="btn btn-primary btn-lg" data-download="macos" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for macOS</a>
+              <div class="download-split" data-download-split>
+                <a id="download-cta" class="btn btn-primary btn-lg download-split-main" data-download-auto data-download-label data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download</a>
+                <button type="button" class="btn btn-primary btn-lg download-split-toggle" aria-haspopup="true" aria-expanded="false" aria-label="Choose a platform">
+                  <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                </button>
+                <ul class="download-split-menu" role="menu" hidden>
+                  <li role="none"><a role="menuitem" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Windows (x64)<span class="dl-ext">.zip</span></a></li>
+                  <li role="none"><a role="menuitem" data-download="macos" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">macOS — Universal<span class="dl-ext">.pkg</span></a></li>
+                </ul>
+              </div>
               <div id="release-meta" class="subtext"><span class="release-version" data-prefix="v">v1.4.1</span> • Requires OBS Studio 30.0.0+</div>
             </div>
           </div>
@@ -474,8 +482,16 @@
           <div class="section-header">
             <h2>Installation</h2>
             <div class="section-actions">
-              <a id="download-secondary" class="btn btn-primary" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for Windows (x64)</a>
-              <a id="download-secondary-macos" class="btn btn-primary" data-download="macos" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download for macOS</a>
+              <div class="download-split" data-download-split>
+                <a id="download-secondary" class="btn btn-primary download-split-main" data-download-auto data-download-label data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Download</a>
+                <button type="button" class="btn btn-primary download-split-toggle" aria-haspopup="true" aria-expanded="false" aria-label="Choose a platform">
+                  <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                </button>
+                <ul class="download-split-menu" role="menu" hidden>
+                  <li role="none"><a role="menuitem" data-download="windows" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">Windows (x64)<span class="dl-ext">.zip</span></a></li>
+                  <li role="none"><a role="menuitem" data-download="macos" href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest">macOS — Universal<span class="dl-ext">.pkg</span></a></li>
+                </ul>
+              </div>
             </div>
           </div>
           
@@ -803,7 +819,7 @@
               <li><a href="https://github.com/JoshuaPotter/replay-buffer-pro/issues" rel="noopener" target="_blank">Report an Issue<svg class="external-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/></svg></a></li>
               <li><a href="https://github.com/JoshuaPotter/replay-buffer-pro/releases" rel="noopener" target="_blank">Releases<svg class="external-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/></svg></a></li>
             </ul>
-            <a href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest" class="footer-download-btn" data-download="windows" rel="noopener" target="_blank">
+            <a href="https://github.com/JoshuaPotter/replay-buffer-pro/releases/latest" class="footer-download-btn" data-download-auto data-download="windows" rel="noopener" target="_blank">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
                 <polyline points="7 10 12 15 17 10"/>

--- a/docs/scripts/download-split.js
+++ b/docs/scripts/download-split.js
@@ -1,0 +1,34 @@
+/**
+ * Split download buttons: a primary action plus a caret that toggles a menu
+ * of the other platform downloads. Enhances any [data-download-split] element.
+ */
+export function initDownloadSplits(splits = []) {
+  splits.forEach(split => {
+    const toggle = split.querySelector('.download-split-toggle');
+    const menu = split.querySelector('.download-split-menu');
+    if (!toggle || !menu) return;
+
+    const close = () => {
+      menu.hidden = true;
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+    const open = () => {
+      menu.hidden = false;
+      toggle.setAttribute('aria-expanded', 'true');
+    };
+
+    toggle.addEventListener('click', (e) => {
+      e.stopPropagation();
+      menu.hidden ? open() : close();
+    });
+
+    // Close after picking an option, when clicking elsewhere, or on Escape.
+    menu.addEventListener('click', close);
+    document.addEventListener('click', (e) => {
+      if (!split.contains(e.target)) close();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') close();
+    });
+  });
+}

--- a/docs/scripts/index.js
+++ b/docs/scripts/index.js
@@ -1,15 +1,24 @@
 /**
  * Main entry point for the Replay Buffer Pro landing page
  */
-import { fetchLatestRelease, applyReleaseVersionToElements, applyDownloadUrls, updateYearByClass } from './utils.js';
+import { fetchLatestRelease, applyReleaseVersionToElements, applyDownloadUrls, applyDetectedOS, updateYearByClass } from './utils.js';
 import { initializePluginSlider } from './plugin-ui-demo.js';
+import { initDownloadSplits } from './download-split.js';
 
 // ES module scripts with defer are guaranteed to run after DOM parsing,
 // so DOMContentLoaded wrapping is unnecessary and can cause missed events.
 initializePluginSlider();
 
+// Default the auto-targeted download buttons to the visitor's OS (synchronous,
+// so the primary button shows the right platform before the release fetch lands).
+applyDetectedOS(document.querySelectorAll('[data-download-auto]'));
+
+// Wire up the split download buttons' caret menus.
+initDownloadSplits(document.querySelectorAll('[data-download-split]'));
+
 // Fetch the latest release once, then update the displayed version and point
-// each platform's download buttons at the matching release asset.
+// each platform's download buttons at the matching release asset. This runs
+// after applyDetectedOS so the auto buttons already carry the right platform.
 const releaseVersion = document.querySelectorAll('.release-version');
 const downloadLinks = document.querySelectorAll('[data-download]');
 fetchLatestRelease()

--- a/docs/scripts/utils.js
+++ b/docs/scripts/utils.js
@@ -34,6 +34,33 @@ export function applyDownloadUrls(elements, assets = []) {
   });
 }
 
+const OS_LABELS = {
+  windows: 'Download for Windows (x64)',
+  macos: 'Download for macOS',
+};
+
+// Best-effort detection of the visitor's desktop OS. There is no Linux build,
+// so anything that isn't macOS falls back to Windows.
+export function detectOS() {
+  const platform = navigator.userAgentData?.platform || navigator.platform || '';
+  const ua = navigator.userAgent || '';
+  if (/mac/i.test(platform) || /Mac OS X|Macintosh/i.test(ua)) return 'macos';
+  return 'windows';
+}
+
+// Point every [data-download-auto] element at the detected OS so its download
+// link resolves to that platform's asset. Elements also marked
+// [data-download-label] get their visible label set to match.
+export function applyDetectedOS(elements, os = detectOS()) {
+  if (!elements) return;
+  elements.forEach(el => {
+    el.dataset.download = os;
+    if (el.hasAttribute('data-download-label')) {
+      el.textContent = OS_LABELS[os] ?? 'Download';
+    }
+  });
+}
+
 export function updateYearByClass(yearEls = []) {
   yearEls.forEach(el => {
     el.textContent = new Date().getFullYear();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -44,6 +44,54 @@ ol { color: var(--muted); }
 .btn-primary:hover { box-shadow: 0 0.125rem 1rem rgba(107, 163, 255, .4); filter: brightness(1.05); }
 .btn-lg {padding: 0.625rem 1.25rem; font-weight: 600; }
 
+/* Split download button: main action + caret that opens a platform menu */
+.download-split { position: relative; display: inline-flex; align-items: stretch; }
+.download-split-main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.download-split-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 0.0625rem solid rgba(11, 13, 16, 0.25); /* divider bar */
+  cursor: pointer;
+  font: inherit;
+}
+.download-split-toggle .caret { transition: transform .15s ease; }
+.download-split-toggle[aria-expanded="true"] .caret { transform: rotate(180deg); }
+.download-split-menu {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  right: 0;
+  min-width: 100%;
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  background: #14181d;
+  border: 0.0625rem solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.375rem;
+  box-shadow: var(--shadow);
+  z-index: 50;
+}
+.download-split-menu[hidden] { display: none; }
+.download-split-menu a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  white-space: nowrap;
+  color: var(--text);
+  text-decoration: none;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+.download-split-menu a:hover { background: rgba(255, 255, 255, 0.08); }
+.download-split-menu .dl-ext { color: var(--muted); font-weight: 500; margin-left: 0.25rem; }
+
 .badge { background: rgba(255,255,255,0.1); padding: 0.25rem 0.625rem; border-radius: 1rem; font-size: 0.875rem; font-weight: 600; }
 
 .container {


### PR DESCRIPTION
Replaces the dual Windows/macOS download buttons with a single split button:

- **Primary action auto-targets the visitor's OS** (macOS vs Windows; no Linux build, so non-macOS falls back to Windows).
- **A caret + divider bar opens a menu** of all platform downloads — Windows `.zip` and macOS `.pkg` — each resolving to the real versioned release asset (reuses the asset-URL resolution added previously).
- Applied to the hero and Installation CTAs; the header and footer download buttons are made OS-aware (no menu).

## Implementation
- `docs/scripts/utils.js` — `detectOS()` + `applyDetectedOS()`.
- `docs/scripts/download-split.js` (new) — `initDownloadSplits()` for the caret menu (click toggle, close on outside-click / Escape / selection; `aria-expanded`/`aria-haspopup`).
- `docs/index.html` — split-button markup; `data-download-auto` on header/footer.
- `docs/styles.css` — split button + dropdown styling.

## Verification
- JS syntax-checked; OS detection + label + URL-resolution unit-tested (mac/win/linux; label only updates the split-main, preserving the footer version span).
- Rendered in a browser: split button shows the detected OS, caret opens the platform menu, no console errors.