### PR TITLE
docs: note Smart Replay Mover compatibility for file naming

### DIFF
--- a/reference/architecture/replay-buffer-flow.md
+++ b/reference/architecture/replay-buffer-flow.md
@@ -31,6 +31,10 @@ This document explains how the plugin saves replay buffer content and trims it t
   - Calls `VideoTrimmer::trimToLastSeconds(...)`.
   - Deletes the original file with `os_unlink(...)` on success.
 
+## Third-party compatibility
+- [Smart Replay Mover](https://github.com/SlonickLab/Smart-Replay-Mover) (SlonickLab) is a third-party OBS Lua script that waits for this plugin to finish trimming, then moves the final `_trimmed` file into per-game folders. See [issue #23](https://github.com/JoshuaPotter/replay-buffer-pro/issues/23).
+- If the `_trimmed` suffix, the original-file deletion, or the timing of when the final file appears changes, open an issue at https://github.com/SlonickLab/Smart-Replay-Mover so they can update their compatibility handling.
+
 ## Error handling
 - UI warnings show when the replay buffer is inactive or the requested duration is too long.
 - Trimming errors are logged via `Logger::error(...)` but do not raise UI alerts.


### PR DESCRIPTION
## Summary
- Documents that Smart Replay Mover (SlonickLab), a third-party OBS Lua script, relies on the `_trimmed` suffix and the deletion of the original saved-replay file to detect when trimming is finished before moving files into per-game folders.
- Adds a note so that any future change to that naming/deletion behavior prompts a heads-up issue on the Smart Replay Mover repo to preserve compatibility, per the commitment made in #23.

## Why
Closes the documentation follow-up promised in #23, where SlonickLab requested permission to make their script compatible with Replay Buffer Pro's trimming behavior.

## Test plan
- [x] Docs-only change; no code affected.
- [x] Verified the new section renders correctly in `reference/architecture/replay-buffer-flow.md`.

Refs #23