### PR TITLE
fix: add padded wrapper container to dock

### DIFF
--- a/reference/architecture/ui-layer.md
+++ b/reference/architecture/ui-layer.md
@@ -9,7 +9,7 @@ This document describes the dockable UI panel and the widget components that con
 - Periodically reload buffer length from OBS settings.
 
 ## UI composition
-The dock assembles a vertical layout that includes:
+The dock content is wrapped in a padded `QFrame` (`replayBufferProFrame`, `NoFrame` shape), mirroring the `controlsFrame`/`scenesFrame` pattern native OBS docks use to get a consistent gutter between the dock's border and its content. Inside it, the dock assembles a vertical layout that includes:
 - Subtitle label (`WidgetTitle`).
 - Buffer length header with a label and seconds input (`QSpinBox`).
 - Buffer length slider (`QSlider`).

--- a/src/ui/ui-components.cpp
+++ b/src/ui/ui-components.cpp
@@ -83,8 +83,27 @@ namespace ReplayBufferPro
 
   QWidget *UIComponents::createUI()
   {
-    QWidget *container = new QWidget();
+    // Wrap content in a QFrame matching OBS's own native-dock pattern
+    // (e.g. controlsFrame/scenesFrame), so the dock gets the same boxed,
+    // padded look as native docks. The background/border is drawn
+    // explicitly here (rather than relying on OBS's theme QSS, which
+    // targets its own dock widgets by name and doesn't reliably paint on
+    // a plain QWidget) using palette-relative colors so it still adapts
+    // to light/dark OBS themes.
+    QFrame *container = new QFrame();
+    container->setObjectName("replayBufferProFrame");
+    container->setFrameShape(QFrame::NoFrame);
+    container->setStyleSheet(
+      "QFrame#replayBufferProFrame {"
+      "  background: palette(base);"
+      "  border: 1px solid palette(mid);"
+      "  border-top: none;"
+      "  border-bottom-left-radius: 4px;"
+      "  border-bottom-right-radius: 4px;"
+      "}"
+    );
     QVBoxLayout *mainLayout = new QVBoxLayout(container);
+    mainLayout->setContentsMargins(8, 8, 8, 8);
 
     // Add the configuration title as a subtitle
     QLabel* subtitle = new QLabel(obs_module_text("WidgetTitle"), container);


### PR DESCRIPTION
## Summary
Our dock's content sat flush against the dock's edges, unlike native OBS docks (Controls, Scenes) which have a padded, boxed panel look.

## Change
- `UIComponents::createUI()` now wraps content in a `QFrame` (`replayBufferProFrame`) with an explicit background/border/padding, matching the pattern native OBS docks use internally (`controlsFrame`, `scenesFrame`, etc.).
- The background/border is drawn explicitly with palette-relative colors (`palette(base)`/`palette(mid)`) rather than relying on OBS's theme QSS, since that QSS targets OBS's own dock widgets by object name and doesn't reliably paint on our plain `QWidget`.
- Updated `reference/architecture/ui-layer.md` to document the new wrapper frame.

## Verification
Built and installed locally (`cmake --build --preset windows-x64` / `cmake --install`), confirmed in a running OBS 32.2.1 instance that the dock now shows a boxed, padded panel consistent with native docks.