### PR TITLE
fix: match dock border color to header background

### DIFF
--- a/src/ui/ui-components.cpp
+++ b/src/ui/ui-components.cpp
@@ -96,7 +96,7 @@ namespace ReplayBufferPro
     container->setStyleSheet(
       "QFrame#replayBufferProFrame {"
       "  background: palette(base);"
-      "  border: 1px solid palette(mid);"
+      "  border: 1px solid palette(button);"
       "  border-top: none;"
       "  border-bottom-left-radius: 4px;"
       "  border-bottom-right-radius: 4px;"


### PR DESCRIPTION
## Summary
Follow-up to #32 — the dock's wrapper frame border used `palette(mid)`, which didn't match the dock header's background color like other plugins' docks do.

## Change
- `src/ui/ui-components.cpp`: border color changed from `palette(mid)` to `palette(button)`, which OBS's theme maps to the same color as `QDockWidget::title`'s background (`--button_bg`).

## Verification
Built, installed, and confirmed in a running OBS 32.2.1 instance that the border now matches the dock's header background.