### PR TITLE
Replace buffer length slider with a spinbox number-wheel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file is a concise handoff for agents working in the Replay Buffer Pro OBS p
 ## Architecture map (start here)
 - Module entry + OBS integration: `src/main.cpp`
 - Dock widget + UI orchestration: `src/plugin/plugin.hpp`, `src/plugin/plugin.cpp`
-- UI components + tick labels: `src/ui/ui-components.hpp`, `src/ui/ui-components.cpp`
+- UI components: `src/ui/ui-components.hpp`, `src/ui/ui-components.cpp`
 - Replay buffer manager: `src/managers/replay-buffer-manager.hpp`, `src/managers/replay-buffer-manager.cpp`
 - Settings manager: `src/managers/settings-manager.hpp`, `src/managers/settings-manager.cpp`
 - Save button settings: `src/managers/save-button-settings.hpp`, `src/managers/save-button-settings.cpp`
@@ -23,7 +23,7 @@ This file is a concise handoff for agents working in the Replay Buffer Pro OBS p
 
 ## Core runtime flows
 ### Buffer length update
-1. Slider/spinbox/tick label changes value in the dock.
+1. User steps or types a new value into the buffer length spinbox in the dock.
 2. Debounce timer expires.
 3. `SettingsManager::updateBufferLengthSettings(...)` writes `RecRBTime` into OBS profile config.
 4. If a replay output exists, updates `max_time_sec` and calls `obs_output_update(...)`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -268,34 +268,31 @@
                 <div class="plugin-section">
                   <h3 class="plugin-section-title">Replay Buffer Settings</h3>
                   
-                  <div class="slider-container">
-                    <label class="slider-label">
-                      <span>Maximum Replay Buffer Length</span>
-                      <span class="slider-value-wrapper">
-                        <input type="number" class="slider-value-input" id="slider-value-input" value="7200" min="1" max="21600" step="1">
-                        <span class="slider-value-unit">sec</span>
-                      </span>
-                    </label>
-                    <div class="slider-wrapper">
-                      <input 
-                        type="range" 
-                        class="buffer-slider" 
-                        id="buffer-slider"
-                        min="1" 
-                        max="21600" 
-                        value="7200" 
+                  <div class="buffer-length-container">
+                    <label class="buffer-length-label" for="buffer-length-input">Maximum Replay Buffer Length</label>
+                    <div class="buffer-number-input" id="buffer-number-input">
+                      <input
+                        type="number"
+                        class="buffer-length-value-input"
+                        id="buffer-length-input"
+                        value="7200"
+                        min="1"
+                        max="21600"
                         step="1"
-                      />
-                      <div class="slider-track-fill" id="slider-fill"></div>
-                    </div>
-                    <div class="slider-markers">
-                      <button type="button" class="slider-marker" data-value="300">5m</button>
-                      <button type="button" class="slider-marker" data-value="3600">1h</button>
-                      <button type="button" class="slider-marker" data-value="7200">2h</button>
-                      <button type="button" class="slider-marker" data-value="10800">3h</button>
-                      <button type="button" class="slider-marker" data-value="14400">4h</button>
-                      <button type="button" class="slider-marker" data-value="18000">5h</button>
-                      <button type="button" class="slider-marker" data-value="21600">6h</button>
+                      >
+                      <span class="buffer-length-unit">sec</span>
+                      <div class="buffer-number-steppers">
+                        <button type="button" class="buffer-number-step" id="buffer-step-up" aria-label="Increase buffer length">
+                          <svg width="8" height="5" viewBox="0 0 8 5" fill="none">
+                            <path d="M1 4l3-3 3 3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+                          </svg>
+                        </button>
+                        <button type="button" class="buffer-number-step" id="buffer-step-down" aria-label="Decrease buffer length">
+                          <svg width="8" height="5" viewBox="0 0 8 5" fill="none">
+                            <path d="M1 1l3 3 3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+                          </svg>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -580,7 +577,7 @@
               <div class="step-card">
                 <div class="step-badge">3</div>
                 <div class="step-content">
-                  <p>Adjust the Replay Buffer length using the slider.</p>
+                  <p>Adjust the Replay Buffer length using the numeric field.</p>
                 </div>
               </div>
               <div class="step-card">
@@ -631,7 +628,7 @@
                 </svg>
               </div>
               <h3>Adjusting Buffer Length</h3>
-              <p>Adjust the Replay Buffer length easily with the slider in the plugin UI, bypassing the settings menu.</p>
+              <p>Adjust the Replay Buffer length easily with the numeric field in the plugin UI, bypassing the settings menu.</p>
             </article>
 
             <article class="feature">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,7 +24,7 @@ Replay Buffer Pro is a free, open-source plugin for OBS Studio that expands upon
 1. **Custom Save Buttons**: Save any custom clip length instantly with fully customizable save buttons
 2. **No Re-encoding**: Uses libavformat with stream copy for fast, lossless output
 3. **Hotkey Support**: Assign hotkeys for each save button in OBS settings
-4. **Adjustable Buffer Length**: Set replay buffer from 1 second to 6 hours via slider
+4. **Adjustable Buffer Length**: Set replay buffer from 1 second to 6 hours via a numeric input
 5. **Dockable UI**: Minimal, clean interface that docks in OBS Studio
 6. **Automatic Trimming**: Saves full buffer then trims to desired length automatically
 
@@ -56,7 +56,7 @@ Replay Buffer Pro is a free, open-source plugin for OBS Studio that expands upon
 
 1. Open OBS Studio
 2. Show the Replay Buffer Pro dock: **Docks → Replay Buffer Pro**
-3. Adjust the Replay Buffer length using the slider (optional)
+3. Adjust the Replay Buffer length using the numeric field (optional)
 4. Start the Replay Buffer from OBS
 5. Click a save button (e.g., "Last 30 Seconds") or trigger its hotkey to save a clip
 

--- a/docs/scripts/index.js
+++ b/docs/scripts/index.js
@@ -2,13 +2,13 @@
  * Main entry point for the Replay Buffer Pro landing page
  */
 import { fetchLatestRelease, applyReleaseVersionToElements, applyDownloadUrls, applyDetectedOS, detectOS, updateYearByClass } from './utils.js';
-import { initializePluginSlider } from './plugin-ui-demo.js';
+import { initializePluginBufferInput } from './plugin-ui-demo.js';
 import { initDownloadSplits } from './download-split.js';
 import { initOsTabs } from './install-tabs.js';
 
 // ES module scripts with defer are guaranteed to run after DOM parsing,
 // so DOMContentLoaded wrapping is unnecessary and can cause missed events.
-initializePluginSlider();
+initializePluginBufferInput();
 
 // Default the auto-targeted download buttons to the visitor's OS (synchronous,
 // so the primary button shows the right platform before the release fetch lands).

--- a/docs/scripts/plugin-ui-demo.js
+++ b/docs/scripts/plugin-ui-demo.js
@@ -125,9 +125,9 @@ function initializeCustomizeModal() {
 
     applyDurationsToButtons();
 
-    // Re-evaluate disabled states against the current slider value
-    const slider = document.getElementById('buffer-slider');
-    const bufferLength = slider ? parseInt(slider.value, 10) : 21600;
+    // Re-evaluate disabled states against the current buffer length value
+    const bufferInput = document.getElementById('buffer-length-input');
+    const bufferLength = bufferInput ? parseInt(bufferInput.value, 10) : 21600;
     updateClipButtonStates(bufferLength);
 
     closeModal();
@@ -161,98 +161,52 @@ function initializeCustomizeModal() {
 }
 
 /**
- * Initializes the plugin UI demo slider interactions
+ * Initializes the plugin UI demo buffer length number-input interactions
  */
-export function initializePluginSlider() {
-  const slider = document.getElementById('buffer-slider');
-  const sliderValueInput = document.getElementById('slider-value-input');
-  const sliderFill = document.getElementById('slider-fill');
-  const sliderMarkers = document.querySelectorAll('.slider-marker');
+export function initializePluginBufferInput() {
+  const bufferInput = document.getElementById('buffer-length-input');
+  const stepUpBtn = document.getElementById('buffer-step-up');
+  const stepDownBtn = document.getElementById('buffer-step-down');
 
-  if (!slider || !sliderValueInput || !sliderFill) return;
+  if (!bufferInput) return;
 
-  const min = parseInt(slider.min);
-  const max = parseInt(slider.max);
+  const min = parseInt(bufferInput.min);
+  const max = parseInt(bufferInput.max);
 
-  function updateFromSlider() {
-    const value = parseInt(slider.value);
-    
-    // Update input value
-    sliderValueInput.value = value;
-    
-    // Update fill width
-    const percentage = ((value - min) / (max - min)) * 100;
-    sliderFill.style.width = `${percentage}%`;
-  }
-
-  function updateFromInput() {
-    let value = parseInt(sliderValueInput.value);
-    
-    // Only update if value is valid and within range
-    if (!isNaN(value) && value >= min && value <= max) {
-      slider.value = value;
-      const percentage = ((value - min) / (max - min)) * 100;
-      sliderFill.style.width = `${percentage}%`;
-    }
+  function clampToRange(value) {
+    if (isNaN(value)) return min;
+    return Math.max(min, Math.min(max, value));
   }
 
   function validateAndClampInput() {
-    let value = parseInt(sliderValueInput.value);
-    
-    // Validate and clamp value
-    if (isNaN(value)) {
-      value = min;
-    } else if (value < min) {
-      value = min;
-    } else if (value > max) {
-      value = max;
-    }
-    
-    // Update input and slider
-    sliderValueInput.value = value;
-    slider.value = value;
-    
-    // Update fill width
-    const percentage = ((value - min) / (max - min)) * 100;
-    sliderFill.style.width = `${percentage}%`;
+    const value = clampToRange(parseInt(bufferInput.value));
+    bufferInput.value = value;
+    updateClipButtonStates(value);
   }
 
-  // Initialize on load
-  updateFromSlider();
+  function step(delta) {
+    const value = clampToRange(parseInt(bufferInput.value) + delta);
+    bufferInput.value = value;
+    updateClipButtonStates(value);
+  }
 
   // Apply initial button labels from currentDurations
   applyDurationsToButtons();
 
-  // Update on slider input
-  slider.addEventListener('input', updateFromSlider);
+  // Update button states as the user types (without clamping mid-edit)
+  bufferInput.addEventListener('input', () => {
+    updateClipButtonStates(parseInt(bufferInput.value));
+  });
 
-  // Update slider as user types (without clamping)
-  sliderValueInput.addEventListener('input', updateFromInput);
-  
   // Validate and clamp only when done editing
-  sliderValueInput.addEventListener('blur', validateAndClampInput);
+  bufferInput.addEventListener('blur', validateAndClampInput);
 
-  // Handle marker clicks
-  sliderMarkers.forEach(marker => {
-    marker.addEventListener('click', (e) => {
-      const value = parseInt(e.target.dataset.value);
-      slider.value = value;
-      updateFromSlider();
-      updateClipButtonStates(value);
-    });
-  });
+  // Wire the up/down step buttons
+  if (stepUpBtn) stepUpBtn.addEventListener('click', () => step(1));
+  if (stepDownBtn) stepDownBtn.addEventListener('click', () => step(-1));
 
-  // Update button states on slider change
-  slider.addEventListener('input', () => {
-    updateClipButtonStates(parseInt(slider.value));
-  });
-
-  sliderValueInput.addEventListener('blur', () => {
-    updateClipButtonStates(parseInt(sliderValueInput.value));
-  });
-
-  // Initialize button states based on current slider value
-  updateClipButtonStates(parseInt(slider.value));
+  // Initialize button states based on the current buffer length
+  updateClipButtonStates(parseInt(bufferInput.value));
 
   // Initialize customize modal
   initializeCustomizeModal();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1249,10 +1249,10 @@ details p { color: var(--muted); margin: 0.5rem 0.125rem 0.25rem; }
 }
 
 .customize-btn {
-  background: transparent;
-  border: 0.0625rem solid rgba(255, 255, 255, 0.12);
+  background: #4a5060;
+  border: 0.0625rem solid rgba(0, 0, 0, 0.3);
   border-radius: 0.25rem;
-  color: #9aa7b2;
+  color: #e8eaed;
   font-size: 0.6875rem;
   font-weight: 500;
   font-family: inherit;
@@ -1264,13 +1264,12 @@ details p { color: var(--muted); margin: 0.5rem 0.125rem 0.25rem; }
 }
 
 .customize-btn:hover {
-  background: rgba(255, 255, 255, 0.07);
-  border-color: rgba(255, 255, 255, 0.22);
-  color: #c4cdd6;
+  background: #555c6e;
+  border-color: rgba(255, 255, 255, 0.1);
 }
 
 .customize-btn:active {
-  background: rgba(255, 255, 255, 0.04);
+  opacity: 0.9;
 }
 
 /* ============================================

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -935,39 +935,41 @@ details p { color: var(--muted); margin: 0.5rem 0.125rem 0.25rem; }
   letter-spacing: 0.00625rem;
 }
 
-/* Slider Styles */
-.slider-container {
+/* Buffer Length Number Input Styles */
+.buffer-length-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   margin-bottom: 0.625rem;
 }
 
-.slider-label {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.buffer-length-label {
   font-size: 0.75rem;
-  color: #b4bec9; /* Lightened from #9aa0aa for better contrast */
-  margin-bottom: 0.5rem;
+  color: #b4bec9;
 }
 
-.slider-value-wrapper {
+.buffer-number-input {
   display: flex;
   align-items: center;
   gap: 0.25rem;
   color: #d4d8de;
   font-weight: 500;
   background: #3a3f4a;
-  padding: 0.1875rem 0.5rem;
+  padding: 0.1875rem 0.375rem 0.1875rem 0.5rem;
   border-radius: 0.25rem;
   font-size: 0.6875rem;
+  width: fit-content;
+  flex-shrink: 0;
 }
 
-.slider-value-input {
+.buffer-length-value-input {
   background: transparent;
   border: none;
   color: #d4d8de;
   font-weight: 500;
   font-size: 0.6875rem;
-  width: 2rem;
+  width: 2.75rem;
   text-align: right;
   outline: none;
   padding: 0;
@@ -976,115 +978,45 @@ details p { color: var(--muted); margin: 0.5rem 0.125rem 0.25rem; }
   -moz-appearance: textfield;
 }
 
-.slider-value-input::-webkit-outer-spin-button,
-.slider-value-input::-webkit-inner-spin-button {
+.buffer-length-value-input::-webkit-outer-spin-button,
+.buffer-length-value-input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.slider-value-unit {
+.buffer-length-unit {
   color: #d4d8de;
   font-weight: 500;
 }
 
-.slider-wrapper {
-  position: relative;
-  margin-bottom: 0.375rem;
-  height: 0.375rem;
-  background: #3a3f4a;
-  border-radius: 0.1875rem;
+.buffer-number-steppers {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  margin-left: 0.125rem;
 }
 
-.buffer-slider {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 100%;
-  height: 0.875rem;
-  background: transparent;
-  border-radius: 0.1875rem;
-  outline: none;
-  position: absolute;
-  left: 0;
-  z-index: 2;
-  cursor: pointer;
-}
-
-.buffer-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 0.875rem;
-  height: 0.875rem;
-  background: linear-gradient(180deg, #ffffff, #e8eaed);
-  border: 0.125rem solid #5b6370;
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.3);
-  transition: all 0.15s ease;
-}
-
-.buffer-slider::-moz-range-thumb {
-  -moz-appearance: none;
-  appearance: none;
-  width: 0.875rem;
-  height: 0.875rem;
-  background: linear-gradient(180deg, #ffffff, #e8eaed);
-  border: 0.125rem solid #5b6370;
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.3);
-  transition: all 0.15s ease;
-}
-
-.buffer-slider::-webkit-slider-thumb:hover {
-  background: #ffffff;
-}
-
-.buffer-slider::-moz-range-thumb:hover {
-  background: #ffffff;
-}
-
-.buffer-slider::-webkit-slider-runnable-track,
-.buffer-slider::-moz-range-track {
-  width: 100%;
-  height: 0.375rem;
-  background: transparent;
-  border-radius: 0.1875rem;
-}
-
-.slider-track-fill {
-  height: 0.375rem;
-  background: linear-gradient(90deg, #5b8fd8, #4a7bc4);
-  border-radius: 0.1875rem 0 0 0.1875rem;
-  pointer-events: none;
-  z-index: 1;
-  width: 33.33%;
-}
-
-.slider-markers {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.6875rem;
-  color: #9aa7b2; /* Lightened from #7e8490 for better contrast */
-  padding: 0 0.125rem;
-  user-select: none;
-}
-
-.slider-marker {
+.buffer-number-step {
   background: none;
   border: none;
-  color: #9aa7b2; /* Lightened from #7e8490 for better contrast */
-  font-size: 0.6875rem;
+  color: #9aa7b2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 0.75rem;
+  padding: 0;
   cursor: pointer;
-  padding: 0.125rem 0.25rem;
-  margin: -0.125rem -0.25rem;
-  transition: color 0.15s ease;
-  font-family: inherit;
+  border-radius: 0.125rem;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
-.slider-marker:hover {
-  color: #c4cdd6; /* Lightened for better hover contrast */
+.buffer-number-step:hover {
+  background: #4a505c;
+  color: #c4cdd6;
+}
+
+.buffer-number-step:active {
+  background: #565d6a;
 }
 
 /* Clip Buttons Grid */

--- a/reference/README.md
+++ b/reference/README.md
@@ -13,7 +13,7 @@ If you are new to the plugin, read in order:
 
 ## Runtime overview
 1. OBS loads the module and registers the dock widget.
-2. The dock creates UI controls (slider, spinbox, save buttons, tick labels).
+2. The dock creates UI controls (buffer length spinbox, save buttons).
 3. Buffer length changes update OBS profile config and replay output settings.
 4. Save actions trigger OBS replay buffer save.
 5. When OBS emits the saved event, the plugin trims the saved file in a background thread.

--- a/reference/architecture/module-and-obs-integration.md
+++ b/reference/architecture/module-and-obs-integration.md
@@ -24,7 +24,7 @@ This document covers how the plugin integrates with OBS, how the module lifecycl
 When the dock widget is constructed:
 1. Managers are created (`ReplayBufferManager`, `SettingsManager`).
 2. UI components are created and mounted in a `QVBoxLayout`.
-3. Slider and spinbox signals are connected with a shared debounce timer.
+3. Buffer length spinbox signals are connected with a debounce timer.
 4. Current buffer length is loaded from OBS settings.
 5. OBS frontend event callback is registered.
 6. Hotkeys are registered.

--- a/reference/architecture/ui-layer.md
+++ b/reference/architecture/ui-layer.md
@@ -11,24 +11,15 @@ This document describes the dockable UI panel and the widget components that con
 ## UI composition
 The dock content is wrapped in a padded `QFrame` (`replayBufferProFrame`, `NoFrame` shape), mirroring the `controlsFrame`/`scenesFrame` pattern native OBS docks use to get a consistent gutter between the dock's border and its content. Inside it, the dock assembles a vertical layout that includes:
 - Subtitle label (`WidgetTitle`).
-- Buffer length header with a label and seconds input (`QSpinBox`).
-- Buffer length slider (`QSlider`).
-- Tick label widget for quick duration selection.
-- Divider line.
+- Buffer length header with a label and a seconds spinbox (`QSpinBox`, with its up/down step buttons enabled).
 - Save clip section title, customize button, and a grid of save buttons.
 
 ## UI controls and behavior
 ### Buffer length controls
-- `QSlider` and `QSpinBox` are bound to the same value.
-- A debounce timer (`Config::SLIDER_DEBOUNCE_INTERVAL`) prevents frequent OBS config updates.
-- When the replay buffer is active, the slider and spinbox are disabled.
-- Clicking disabled controls triggers a warning dialog via an event filter.
-
-### Tick label widget
-- `TickLabelWidget` renders time labels such as `5m`, `1h`, `6h` on the slider axis.
-- It dynamically shows or hides labels based on available width.
-- Labels are clickable and update the buffer length value.
-- When the replay buffer is active, clicking labels shows a warning and does not update settings.
+- A single `QSpinBox` is the buffer length control (no separate slider or tick-label row).
+- A debounce timer (`Config::BUFFER_LENGTH_DEBOUNCE_INTERVAL`) prevents frequent OBS config updates while the value is being stepped/typed.
+- When the replay buffer is active, the spinbox is disabled.
+- Clicking or typing into the disabled spinbox triggers a warning dialog via an event filter.
 
 ### Save buttons
 - Save buttons are generated from the current customizable duration settings.
@@ -38,15 +29,15 @@ The dock content is wrapped in a padded `QFrame` (`replayBufferProFrame`, `NoFra
 - A customize button opens a dialog to edit per-button durations.
 
 ## Event and state flow
-1. User adjusts slider/spinbox or clicks a tick label.
-2. `UIComponents::updateBufferLengthValue(...)` syncs slider and spinbox.
+1. User steps or types a new value into the buffer length spinbox.
+2. `UIComponents::updateBufferLengthValue(...)` updates the spinbox and save button enabled states.
 3. Dock restarts the debounce timer and waits for input to settle.
 4. On debounce timeout, `SettingsManager::updateBufferLengthSettings(...)` persists the value.
 5. OBS frontend events update UI enabled/disabled state and reload buffer length when needed.
 
 ## Configuration inputs
-- Slider range uses `Config::MIN_BUFFER_LENGTH` and `Config::MAX_BUFFER_LENGTH`.
-- Debounce interval uses `Config::SLIDER_DEBOUNCE_INTERVAL`.
+- Spinbox range uses `Config::MIN_BUFFER_LENGTH` and `Config::MAX_BUFFER_LENGTH`.
+- Debounce interval uses `Config::BUFFER_LENGTH_DEBOUNCE_INTERVAL`.
 - Save buttons are generated from `SaveButtonSettings` and `Config::SAVE_BUTTON_COUNT`.
 
 ## Key classes and functions
@@ -54,7 +45,6 @@ The dock content is wrapped in a padded `QFrame` (`replayBufferProFrame`, `NoFra
 - `ReplayBufferPro::UIComponents::createUI()`
 - `ReplayBufferPro::UIComponents::updateBufferLengthValue(...)`
 - `ReplayBufferPro::UIComponents::updateBufferLengthState(...)`
-- `ReplayBufferPro::TickLabelWidget` (event filter, resize and show events)
 
 ## Related code
 - `src/plugin/plugin.hpp`

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -27,8 +27,8 @@ namespace ReplayBufferPro
     constexpr const char *HOTKEY_BINDINGS_KEY = "HotkeyBindings";
 
     // Timer intervals
-    constexpr int SETTINGS_MONITOR_INTERVAL = 1000; // 1 second
-    constexpr int SLIDER_DEBOUNCE_INTERVAL = 800;   // 800 milliseconds
+    constexpr int SETTINGS_MONITOR_INTERVAL = 1000;       // 1 second
+    constexpr int BUFFER_LENGTH_DEBOUNCE_INTERVAL = 800;   // 800 milliseconds
 
     // File paths
     constexpr const char *TEMP_FILE_SUFFIX = "tmp";

--- a/src/plugin/plugin.cpp
+++ b/src/plugin/plugin.cpp
@@ -116,13 +116,10 @@ namespace ReplayBufferPro
 
 	void Plugin::initSignals()
 	{
-		// Both slider and spinbox changes will trigger handleSliderChanged
-		connect(ui->getSlider(), &QSlider::valueChanged, this, &Plugin::handleSliderChanged);
-		connect(ui->getSecondsEdit(), QOverload<int>::of(&QSpinBox::valueChanged), 
-				this, &Plugin::handleSliderChanged);  // Use same handler
-		
-		// Single debounce timer for both controls
-		connect(ui->getSliderDebounceTimer(), &QTimer::timeout, this, &Plugin::handleSliderFinished);
+		connect(ui->getSecondsEdit(), QOverload<int>::of(&QSpinBox::valueChanged),
+				this, &Plugin::handleBufferLengthChanged);
+
+		connect(ui->getBufferLengthDebounceTimer(), &QTimer::timeout, this, &Plugin::handleBufferLengthFinished);
 	}
 
 	//=============================================================================
@@ -160,20 +157,20 @@ namespace ReplayBufferPro
 		}
 	}
 
-	void Plugin::handleSliderChanged(int value)
+	void Plugin::handleBufferLengthChanged(int value)
 	{
 		// Only update the UI components, don't trigger settings update yet
 		ui->updateBufferLengthValue(value);
-		
+
 		// Restart the debounce timer
-		ui->getSliderDebounceTimer()->start();
+		ui->getBufferLengthDebounceTimer()->start();
 	}
 
-	void Plugin::handleSliderFinished()
+	void Plugin::handleBufferLengthFinished()
 	{
-		// Get the final slider value
-		int value = ui->getSlider()->value();
-		
+		// Get the final spinbox value
+		int value = ui->getSecondsEdit()->value();
+
 		// Only update settings if the value has actually changed
 		if (value != lastKnownBufferLength)
 		{
@@ -184,23 +181,6 @@ namespace ReplayBufferPro
 				QMessageBox::warning(this, obs_module_text("Error"),
 									QString(obs_module_text("FailedToUpdateLength")).arg(e.what()));
 			}
-		}
-	}
-
-	void Plugin::handleBufferLengthInput(int value)
-	{
-		if (value < Config::MIN_BUFFER_LENGTH || value > Config::MAX_BUFFER_LENGTH)
-		{
-			ui->updateBufferLengthValue(ui->getSlider()->value());
-			return;
-		}
-
-		ui->getSlider()->setValue(value);
-		try {
-			settingsManager->updateBufferLengthSettings(value);
-		} catch (const std::exception &e) {
-			QMessageBox::warning(this, obs_module_text("Error"),
-								QString(obs_module_text("FailedToUpdateLength")).arg(e.what()));
 		}
 	}
 

--- a/src/plugin/plugin.hpp
+++ b/src/plugin/plugin.hpp
@@ -80,31 +80,22 @@ namespace ReplayBufferPro
     // EVENT HANDLERS
     //=========================================================================
     /**
-     * @brief Updates UI and starts debounce timer when slider value changes
+     * @brief Updates UI and starts debounce timer when the buffer length spinbox changes
      * @param value New buffer length in seconds
-     * 
+     *
      * Updates UI immediately and starts debounce timer for OBS settings update.
-     * Prevents rapid OBS settings updates during slider movement.
+     * Prevents rapid OBS settings updates while the value is still being adjusted.
      */
-    void handleSliderChanged(int value);
+    void handleBufferLengthChanged(int value);
 
     /**
-     * @brief Updates OBS settings after slider movement ends
-     * 
-     * Called after slider movement stops and debounce period expires.
-     * Updates OBS settings with the final slider value.
+     * @brief Updates OBS settings after the buffer length value settles
+     *
+     * Called after the debounce period expires following a spinbox change.
+     * Updates OBS settings with the final value.
      * Shows error message if update fails.
      */
-    void handleSliderFinished();
-
-    /**
-     * @brief Validates and applies manual buffer length input
-     * 
-     * Ensures input is within valid range (10s to 6h) and updates settings.
-     * Reverts to previous value if input is invalid.
-     * Shows error message if update fails.
-     */
-    void handleBufferLengthInput(int value);
+    void handleBufferLengthFinished();
 
     /**
      * @brief Updates UI state based on replay buffer activity
@@ -157,7 +148,7 @@ namespace ReplayBufferPro
      * @brief Sets up signal/slot connections
      * 
      * Sets up all event handling connections:
-     * - Slider value changes (with debouncing)
+     * - Buffer length spinbox changes (with debouncing)
      * - Text input validation
      * - Save button clicks
      */

--- a/src/ui/ui-components.cpp
+++ b/src/ui/ui-components.cpp
@@ -127,7 +127,7 @@ namespace ReplayBufferPro
     secondsEdit->setContentsMargins(2, 2, 2, 2);
     headerLayout->addWidget(secondsEdit);
     mainLayout->addLayout(headerLayout);
-    mainLayout->addSpacing(24); // Space before save clip section
+    mainLayout->addSpacing(12); // Space before save clip section
 
     // Save clip label + customize button
     QHBoxLayout *saveClipHeaderLayout = new QHBoxLayout();

--- a/src/ui/ui-components.cpp
+++ b/src/ui/ui-components.cpp
@@ -16,14 +16,12 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QSlider>
 #include <QSpinBox>
 #include <QPushButton>
 #include <QGridLayout>
 #include <QSizePolicy>
 #include <QTimer>
 #include <QFrame>
-#include <QResizeEvent>
 #include <QMessageBox>
 
 // STL includes
@@ -57,12 +55,10 @@ namespace ReplayBufferPro
                              std::function<void(int)> saveSegmentCallback,
                              std::function<void()> saveFullBufferCallback,
                              std::function<void()> customizeSaveButtonsCallback)
-      : slider(nullptr),
-        secondsEdit(nullptr),
+      : secondsEdit(nullptr),
         saveFullBufferBtn(nullptr),
         customizeSaveButtonsBtn(nullptr),
-        sliderDebounceTimer(new QTimer(parent)),
-        tickWidget(nullptr),
+        bufferLengthDebounceTimer(new QTimer(parent)),
         onSaveSegment(saveSegmentCallback),
         onSaveFullBuffer(saveFullBufferCallback),
         onCustomizeSaveButtons(customizeSaveButtonsCallback)
@@ -71,9 +67,9 @@ namespace ReplayBufferPro
         qWarning("UIComponents: parent widget cannot be null");
         return;
     }
-    
-    sliderDebounceTimer->setSingleShot(true);
-    sliderDebounceTimer->setInterval(Config::SLIDER_DEBOUNCE_INTERVAL);
+
+    bufferLengthDebounceTimer->setSingleShot(true);
+    bufferLengthDebounceTimer->setInterval(Config::BUFFER_LENGTH_DEBOUNCE_INTERVAL);
     saveButtonDurations = getDefaultSaveButtonDurations();
   }
 
@@ -125,41 +121,13 @@ namespace ReplayBufferPro
     secondsEdit->setAlignment(Qt::AlignRight);
     secondsEdit->setRange(Config::MIN_BUFFER_LENGTH, Config::MAX_BUFFER_LENGTH);
     secondsEdit->setSuffix(" sec");
-    secondsEdit->setButtonSymbols(QAbstractSpinBox::NoButtons);
     secondsEdit->setCursor(Qt::PointingHandCursor);
     auto* secondsEditFilter = new BufferLengthEventFilter();
     secondsEdit->installEventFilter(secondsEditFilter);
     secondsEdit->setContentsMargins(2, 2, 2, 2);
     headerLayout->addWidget(secondsEdit);
     mainLayout->addLayout(headerLayout);
-    mainLayout->addSpacing(4);
-
-    // Buffer length slider
-    slider = new QSlider(Qt::Horizontal, container);
-    slider->setRange(Config::MIN_BUFFER_LENGTH, Config::MAX_BUFFER_LENGTH);
-    auto* sliderFilter = new BufferLengthEventFilter();
-    slider->installEventFilter(sliderFilter);
-    
-    // Create custom tick label widget
-    tickWidget = new TickLabelWidget(container, &isBufferActive);
-    tickWidget->setFixedHeight(20);
-    tickWidget->setValueCallback([this](int seconds) {
-        updateBufferLengthValue(seconds);
-    });
-    
-    mainLayout->addWidget(slider);
-    mainLayout->setSpacing(0);  // Reduce spacing between slider & ticks
-    mainLayout->addWidget(tickWidget);
-
-    mainLayout->addSpacing(18);  // Space before divider
-
-    // Add horizontal line divider
-    QFrame* line = new QFrame(container);
-    line->setFrameShape(QFrame::HLine);
-    line->setFrameShadow(QFrame::Sunken);
-    mainLayout->addWidget(line);
-    
-    mainLayout->addSpacing(24); // Space after divider
+    mainLayout->addSpacing(24); // Space before save clip section
 
     // Save clip label + customize button
     QHBoxLayout *saveClipHeaderLayout = new QHBoxLayout();
@@ -236,7 +204,6 @@ namespace ReplayBufferPro
 
   void UIComponents::updateBufferLengthValue(int seconds)
   {
-    slider->setValue(seconds);
     secondsEdit->setValue(seconds);
 
     toggleSaveButtons(seconds);
@@ -245,7 +212,6 @@ namespace ReplayBufferPro
   void UIComponents::updateBufferLengthState(bool isActive)
   {
     isBufferActive = isActive;  // Store the active state
-    slider->setEnabled(!isActive);
     secondsEdit->setEnabled(!isActive);
   }
 
@@ -273,7 +239,7 @@ namespace ReplayBufferPro
     }
 
     updateSaveButtonLabels();
-    toggleSaveButtons(slider ? slider->value() : Config::DEFAULT_BUFFER_LENGTH);
+    toggleSaveButtons(secondsEdit ? secondsEdit->value() : Config::DEFAULT_BUFFER_LENGTH);
   }
 
   void UIComponents::updateSaveButtonLabels()
@@ -300,230 +266,4 @@ namespace ReplayBufferPro
     return defaults;
   }
 
-  //=============================================================================
-  // TickLabelWidget Implementation
-  //=============================================================================
-
-  TickLabelWidget::TickLabelWidget(QWidget* parent, bool* isBufferActive) 
-      : QWidget(parent), isBufferActive(isBufferActive) {
-      // Define all possible tick marks (in seconds) in order of priority
-      allTicks = {
-          // Primary tick marks - always shown when space permits
-          {21600, "6h"},   // 6 hours - maximum buffer length
-          {300, "5m"},     // 5 minutes - minimum meaningful segment
-          
-          // Hour markers - shown second if space allows
-          {3600, "1h"},    // 1 hour
-          {7200, "2h"},    // 2 hours  
-          {10800, "3h"},   // 3 hours
-          {14400, "4h"},   // 4 hours
-          {18000, "5h"},   // 5 hours
-          
-          // Half-hour markers - lowest priority, shown last
-          {1800, "30m"},   // 30 minutes
-          {5400, "1.5h"},  // 1.5 hours
-          {9000, "2.5h"},  // 2.5 hours
-          {12600, "3.5h"}, // 3.5 hours
-          {16200, "4.5h"}, // 4.5 hours
-          {19800, "5.5h"}, // 5.5 hours
-
-          // Minute markers - shown third if space allows
-          {2700, "45m"},   // 45 minutes
-          {900, "15m"},    // 15 minutes
-          {600, "10m"},    // 10 minutes
-      };
-
-      // Create all labels (initially hidden)
-      for (const auto& tick : allTicks) {
-          QLabel* label = new QLabel(tick.second, this);
-          label->setAlignment(Qt::AlignCenter);
-          label->adjustSize();
-          label->hide();
-          label->setCursor(Qt::PointingHandCursor); // Show hand cursor on hover
-          label->setStyleSheet("QLabel:hover { color: #999999; }"); // Optional: visual feedback on hover
-          
-          // Install event filter to handle clicks
-          label->installEventFilter(this);
-          labels.push_back(label);
-      }
-  }
-
-  bool TickLabelWidget::eventFilter(QObject* obj, QEvent* event) {
-      if (event->type() == QEvent::MouseButtonRelease) {
-          // Show error dialog if buffer is active
-          if (isBufferActive && *isBufferActive) {
-              QMessageBox::warning(
-                  this,
-                  obs_module_text("Warning"),
-                  obs_module_text("ReplayBufferActive"),
-                  QMessageBox::Ok
-              );
-              return QWidget::eventFilter(obj, event);
-          }
-
-          if (auto* label = qobject_cast<QLabel*>(obj)) {
-              for (size_t i = 0; i < labels.size(); i++) {
-                  if (labels[i] == label && onValueChanged) {
-                      onValueChanged(allTicks[i].first);
-                      break;
-                  }
-              }
-          }
-      }
-      return QWidget::eventFilter(obj, event);
-  }
-
-  void TickLabelWidget::resizeEvent(QResizeEvent* event) {
-      QWidget::resizeEvent(event);
-      updateVisibleTicks();
-      updateTickPositions();
-  }
-
-  void TickLabelWidget::setValueCallback(std::function<void(int)> callback) {
-      onValueChanged = callback;
-  }
-
-  void TickLabelWidget::showEvent(QShowEvent* event) {
-      QWidget::showEvent(event);
-      QTimer::singleShot(0, this, [this]() {
-          updateVisibleTicks();
-          updateTickPositions();
-      });
-  }
-
-  void TickLabelWidget::updateVisibleTicks() {
-      const int totalWidth = width();
-      const int minSpaceBetweenLabels = 50; // Minimum pixels between labels
-      
-      // Hide all labels first
-      for (auto* label : labels) {
-          label->hide();
-      }
-
-      // Always try to show highest priority ticks (6h and 5m) first
-      if (totalWidth >= minSpaceBetweenLabels * 2) {
-          labels[0]->show(); // 6h
-          labels[1]->show(); // 5m
-
-          // Create a list of visible labels to check spacing
-          std::vector<QLabel*> visibleLabels = {labels[0], labels[1]};
-
-          // Try to add hour markers (indices 2-6)
-          for (size_t i = 2; i <= 6; i++) {
-              labels[i]->show();
-              visibleLabels.push_back(labels[i]);
-              
-              // Sort by position
-              std::sort(visibleLabels.begin(), visibleLabels.end(),
-                  [this](QLabel* a, QLabel* b) {
-                      return getTickPosition(a) < getTickPosition(b);
-                  });
-
-              // Check spacing
-              bool hasEnoughSpace = true;
-              for (size_t j = 1; j < visibleLabels.size(); j++) {
-                  double pos1 = getTickPosition(visibleLabels[j-1]) * totalWidth;
-                  double pos2 = getTickPosition(visibleLabels[j]) * totalWidth;
-                  if (pos2 - pos1 < minSpaceBetweenLabels) {
-                      hasEnoughSpace = false;
-                      break;
-                  }
-              }
-
-              if (!hasEnoughSpace) {
-                  labels[i]->hide();
-                  visibleLabels.pop_back();
-              }
-          }
-
-          // Try to add minute markers (indices 7-9)
-          for (size_t i = 7; i <= 9; i++) {
-              labels[i]->show();
-              visibleLabels.push_back(labels[i]);
-              
-              std::sort(visibleLabels.begin(), visibleLabels.end(),
-                  [this](QLabel* a, QLabel* b) {
-                      return getTickPosition(a) < getTickPosition(b);
-                  });
-
-              bool hasEnoughSpace = true;
-              for (size_t j = 1; j < visibleLabels.size(); j++) {
-                  double pos1 = getTickPosition(visibleLabels[j-1]) * totalWidth;
-                  double pos2 = getTickPosition(visibleLabels[j]) * totalWidth;
-                  if (pos2 - pos1 < minSpaceBetweenLabels) {
-                      hasEnoughSpace = false;
-                      break;
-                  }
-              }
-
-              if (!hasEnoughSpace) {
-                  labels[i]->hide();
-                  visibleLabels.pop_back();
-              }
-          }
-
-          // Try to add half-hour markers (indices 10-15) last
-          for (size_t i = 10; i < labels.size(); i++) {
-              labels[i]->show();
-              visibleLabels.push_back(labels[i]);
-              
-              std::sort(visibleLabels.begin(), visibleLabels.end(),
-                  [this](QLabel* a, QLabel* b) {
-                      return getTickPosition(a) < getTickPosition(b);
-                  });
-
-              bool hasEnoughSpace = true;
-              for (size_t j = 1; j < visibleLabels.size(); j++) {
-                  double pos1 = getTickPosition(visibleLabels[j-1]) * totalWidth;
-                  double pos2 = getTickPosition(visibleLabels[j]) * totalWidth;
-                  if (pos2 - pos1 < minSpaceBetweenLabels) {
-                      hasEnoughSpace = false;
-                      break;
-                  }
-              }
-
-              if (!hasEnoughSpace) {
-                  labels[i]->hide();
-                  visibleLabels.pop_back();
-              }
-          }
-      }
-  }
-
-  void TickLabelWidget::updateTickPositions() {
-      const int totalWidth = width();
-      
-      for (size_t i = 0; i < labels.size(); i++) {
-          QLabel* label = labels[i];
-          if (!label->isVisible()) continue;
-
-          double position = static_cast<double>(allTicks[i].first - Config::MIN_BUFFER_LENGTH) / 
-                          (Config::MAX_BUFFER_LENGTH - Config::MIN_BUFFER_LENGTH);
-          
-          int labelWidth = label->sizeHint().width();
-          int x = static_cast<int>(position * totalWidth);
-          
-          // Special handling for 6h mark (first tick) and 5m mark (second tick)
-          if (i == 0) { // 6h mark
-              x = totalWidth - labelWidth; // Always align to far right
-          } else if (i == 1) { // 5m mark
-              x = 0; // Always align to far left
-          } else {
-              // Center all other labels
-              x = std::max(0, std::min(totalWidth - labelWidth, x - labelWidth / 2));
-          }
-          
-          label->move(x, 0);
-      }
-  }
-
-  double TickLabelWidget::getTickPosition(QLabel* label) {
-      for (size_t i = 0; i < labels.size(); i++) {
-          if (labels[i] == label) {
-              return static_cast<double>(allTicks[i].first - Config::MIN_BUFFER_LENGTH) / 
-                     (Config::MAX_BUFFER_LENGTH - Config::MIN_BUFFER_LENGTH);
-          }
-      }
-      return 0.0;
-  }
 } // namespace ReplayBufferPro

--- a/src/ui/ui-components.cpp
+++ b/src/ui/ui-components.cpp
@@ -117,7 +117,7 @@ namespace ReplayBufferPro
     
     // Buffer length seconds input box
     secondsEdit = new QSpinBox(container);
-    secondsEdit->setFixedWidth(80);
+    secondsEdit->setFixedWidth(104);
     secondsEdit->setAlignment(Qt::AlignRight);
     secondsEdit->setRange(Config::MIN_BUFFER_LENGTH, Config::MAX_BUFFER_LENGTH);
     secondsEdit->setSuffix(" sec");

--- a/src/ui/ui-components.hpp
+++ b/src/ui/ui-components.hpp
@@ -11,7 +11,6 @@
 
 // Qt includes
 #include <QWidget>
-#include <QSlider>
 #include <QSpinBox>
 #include <QPushButton>
 #include <QLabel>
@@ -20,10 +19,6 @@
 #include <QGridLayout>
 #include <QTimer>
 #include <QPaintEvent>
-#include <QResizeEvent>
-#include <QShowEvent>
-#include <QStyle>
-#include <QStyleOptionSlider>
 
 // STL includes
 #include <vector>
@@ -34,34 +29,12 @@
 
 namespace ReplayBufferPro
 {
-  // Add this before the UIComponents class
-  class TickLabelWidget : public QWidget {
-  public:
-    explicit TickLabelWidget(QWidget* parent = nullptr, bool* isBufferActive = nullptr);
-    void setValueCallback(std::function<void(int)> callback);
-
-  protected:
-    bool eventFilter(QObject* obj, QEvent* event) override;
-    void resizeEvent(QResizeEvent* event) override;
-    void showEvent(QShowEvent* event) override;
-
-  private:
-    void updateVisibleTicks();
-    void updateTickPositions();
-    double getTickPosition(QLabel* label);
-
-    std::vector<std::pair<int, QString>> allTicks;
-    std::vector<QLabel*> labels;
-    bool* isBufferActive;
-    std::function<void(int)> onValueChanged;
-  };
-
   /**
    * @class UIComponents
    * @brief Manages UI components for the Replay Buffer Pro plugin
    *
    * This class creates and manages the UI components used by the plugin,
-   * including the buffer length slider, text input, and save buttons.
+   * including the buffer length spinbox and save buttons.
    */
   class UIComponents
   {
@@ -88,12 +61,6 @@ namespace ReplayBufferPro
     //=========================================================================
     // GETTERS
     //=========================================================================
-    /**
-     * @brief Gets the buffer length slider
-     * @return Pointer to the buffer length slider
-     */
-    QSlider *getSlider() const { return slider; }
-
     /**
      * @brief Gets the buffer length text input
      * @return Pointer to the buffer length text input
@@ -125,10 +92,10 @@ namespace ReplayBufferPro
     QPushButton *getCustomizeSaveButtonsBtn() const { return customizeSaveButtonsBtn; }
 
     /**
-     * @brief Gets the slider debounce timer
-     * @return Pointer to the slider debounce timer
+     * @brief Gets the buffer length debounce timer
+     * @return Pointer to the buffer length debounce timer
      */
-    QTimer *getSliderDebounceTimer() const { return sliderDebounceTimer; }
+    QTimer *getBufferLengthDebounceTimer() const { return bufferLengthDebounceTimer; }
 
     //=========================================================================
     // UI CREATION
@@ -170,13 +137,11 @@ namespace ReplayBufferPro
     //=========================================================================
     // UI COMPONENTS
     //=========================================================================
-    QSlider *slider;                        ///< Buffer length control (10s to 6h)
-    QSpinBox *secondsEdit;                 ///< Manual buffer length input
+    QSpinBox *secondsEdit;                 ///< Buffer length control (1s to 6h)
     QPushButton *saveFullBufferBtn;         ///< Full buffer save trigger
     QPushButton *customizeSaveButtonsBtn;   ///< Customize save buttons trigger
     std::vector<QPushButton *> saveButtons; ///< Duration-specific save buttons
-    QTimer *sliderDebounceTimer;            ///< Prevents rapid setting updates
-    TickLabelWidget* tickWidget;  // Now this will work
+    QTimer *bufferLengthDebounceTimer;      ///< Prevents rapid setting updates
     std::vector<int> saveButtonDurations;   ///< Durations for save buttons
 
     //=========================================================================


### PR DESCRIPTION
Swaps the slider + tick labels for a plain spinbox with up/down buttons and drops the divider, to cut visual clutter. Updates the docs site demo and reference docs to match.