### PR TITLE
fix: make replay trimming reliable and diagnosable (#25)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This file is a concise handoff for agents working in the Replay Buffer Pro OBS p
 - Settings manager: `src/managers/settings-manager.hpp`, `src/managers/settings-manager.cpp`
 - Save button settings: `src/managers/save-button-settings.hpp`, `src/managers/save-button-settings.cpp`
 - Hotkey manager: `src/managers/hotkey-manager.hpp`, `src/managers/hotkey-manager.cpp`
-- Utilities: `src/utils/obs-utils.*`, `src/utils/logger.hpp`, `src/utils/video-trimmer.*`
+- Utilities: `src/utils/obs-utils.*`, `src/utils/logger.hpp`, `src/utils/video-trimmer.*`, `src/utils/status-reporter.*`
 - Config constants: `src/config/config.hpp`
 - Localization: `data/locale/en-US.ini`
 - Build system: `CMakeLists.txt`, `buildspec.json`, `CMakePresets.json`, `cmake/`
@@ -31,13 +31,20 @@ This file is a concise handoff for agents working in the Replay Buffer Pro OBS p
 ### Save segment
 1. User clicks a duration button or hotkey.
 2. `ReplayBufferManager::saveSegment(...)` validates buffer active and duration <= current length.
-3. `obs_frontend_replay_buffer_save()` is called and `pendingSaveDuration` is set.
-4. On `OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED`, the saved path is trimmed in a background thread.
+3. The request is pushed onto a pending-save FIFO and `obs_frontend_replay_buffer_save()` is called.
+4. On `OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED`, `handleSaveCompleted(...)` pops the matching request and queues a trim job.
+5. The manager's worker thread trims to a `.rbp-partial.<ext>` file, verifies its duration, renames it to `_trimmed`, then deletes the original.
 
 ### Save full buffer
 1. User clicks “Save Replay Buffer”.
-2. `ReplayBufferManager::saveFullBuffer(...)` saves without setting `pendingSaveDuration`.
-3. Saved event occurs, but no trimming is performed.
+2. `ReplayBufferManager::saveFullBuffer(...)` queues a `0`-duration do-not-trim marker, then saves.
+3. The saved event consumes that marker, so no trimming is performed and no stale duration can be inherited.
+
+### Correlating saves
+- OBS cannot tie a save request to the file it produces, so requests are matched to saved events in FIFO order.
+- Requests expire after `Config::TRIM_REQUEST_TIMEOUT_MS` (OBS silently drops saves when encoders are paused).
+- Requests within `Config::TRIM_REQUEST_COALESCE_MS` collapse into one, because OBS produces a single file for presses that close together.
+- A saved event with nothing pending came from outside the plugin (OBS's own hotkey, tray, obs-websocket) and is logged but not trimmed.
 
 ## Key components and ownership
 - `ReplayBufferPro::Plugin` (dock) owns UI, managers, timers, and OBS event wiring.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ target_sources(
     src/utils/duration-format.hpp
     src/utils/video-trimmer.cpp
     src/utils/video-trimmer.hpp
+    src/utils/status-reporter.cpp
+    src/utils/status-reporter.hpp
     src/utils/logger.hpp
     src/ui/ui-components.cpp
     src/ui/ui-components.hpp

--- a/README.md
+++ b/README.md
@@ -165,9 +165,18 @@ replay-buffer-pro/
 
 - Verify plugin file location (`.dll` on Windows, `.plugin` bundle on macOS)
 - Check OBS logs for errors
-- For trimming issues:
-  - Check disk space
-  - Check write permissions in output directory
+
+### A clip wasn't trimmed
+
+Every replay save writes one `TRIM VERDICT` line to the OBS log (**Help → Log Files → Show Log Files**). Search the log for `TRIM VERDICT` and find the line matching the clip:
+
+- `skipped reason=no-pending-request` — the save was triggered outside this plugin, so it was saved at full buffer length. OBS's own **Save Replay** hotkey, the tray menu item, and Stream Deck buttons using the official *OBS Studio* plugin's "Save Replay Buffer" action all take this path. Use one of Replay Buffer Pro's own **Save Clip** hotkeys (Settings → Hotkeys → *Replay Buffer Pro: Save ...*) so the plugin knows which duration you wanted.
+- `skipped reason=save-full-buffer` — this was a **Save Replay Buffer** click, which is intentionally untrimmed.
+- `failed reason=output-too-long` — your encoder's keyframe interval is too long for the clip length you asked for, so the cut could not land near the right place. Set **Settings → Output → Keyframe Interval** to 2 seconds.
+- `failed reason=open-input-failed` — something else was holding the file. If **Settings → Output → Automatically remux to mp4** is enabled, try turning it off; antivirus and cloud-sync folders can do the same.
+- Any other `failed reason=...` — check disk space and write permissions in the output directory, and include the line when reporting an issue.
+
+A failed trim always leaves your original full-length clip in place, so nothing is lost.
 - When building from source:
   - **Windows**: Ensure Visual Studio 2022+ and CMake 3.28+ are installed
   - **macOS**: Ensure Xcode 26.5+ (with macOS SDK 26.5+) and CMake 3.28+ are installed; run `xcode-select --install` if needed

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -24,3 +24,5 @@ ReplayBufferNotActive="The replay buffer is not currently active. Please start t
 FailedToUpdateLength="Failed to update replay buffer length: %1. Please try again or check OBS settings."
 CannotSaveSegment="Cannot save last %1 seconds - the replay buffer is only %2 seconds long. Please increase buffer length or choose a shorter duration."
 FailedToTrimReplay="Failed to trim replay to requested duration: %1. Please ensure FFmpeg is installed correctly."
+StatusTrimSuccess="Replay Buffer Pro: saved last %1"
+StatusTrimFailed="Replay Buffer Pro: trim failed (%1) - full-length clip kept"

--- a/docs/index.html
+++ b/docs/index.html
@@ -707,8 +707,10 @@
                 </svg>
               </div>
               <div class="troubleshoot-content">
-                <strong>Trimming Fails</strong>
-                <p>Check disk space and write permissions in the output directory.</p>
+                <strong>A Clip Wasn't Trimmed</strong>
+                <p>Every replay save writes one <code>TRIM VERDICT</code> line to the OBS log (<strong>Help &rarr; Log Files &rarr; Show Log Files</strong>). Search for <code>TRIM VERDICT</code> and find the line for that clip &mdash; the <code>reason</code> field names the cause. A failed trim always leaves your original full-length clip in place, so nothing is lost.</p>
+                <p><code>skipped reason=no-pending-request</code> means the save came from outside the plugin &mdash; OBS's own <strong>Save Replay</strong> hotkey, the tray menu, or a Stream Deck button using the official OBS Studio plugin's "Save Replay Buffer" action. Those save the full buffer. Bind a <em>Replay Buffer Pro: Save&hellip;</em> hotkey instead so the plugin knows which duration you wanted.</p>
+                <p><code>failed reason=output-too-long</code> means your encoder's keyframe interval is too long for the clip length you asked for. Set <strong>Settings &rarr; Output &rarr; Keyframe Interval</strong> to 2 seconds. For <code>failed reason=open-input-failed</code>, try disabling <strong>Automatically remux to mp4</strong>; antivirus and cloud-sync folders can hold the file the same way. For anything else, check disk space and write permissions in the output directory.</p>
               </div>
             </div>
             

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -101,10 +101,14 @@ A: Windows 10/11 (64-bit) and macOS 12.0+.
 - Restart OBS Studio after placing the file
 - Check OBS logs for "Replay Buffer Pro" entries
 
-**Trimming Fails**
-- Confirm locale files exist at `%ALLUSERSPROFILE%\obs-studio\plugins\replay-buffer-pro\data\locale\`
-- Check disk space availability
-- Verify write permissions in output directory
+**A Clip Wasn't Trimmed**
+- Every replay save writes one `TRIM VERDICT` line to the OBS log. Search the log for `TRIM VERDICT` and read the `reason` field on the line for that clip
+- `skipped reason=no-pending-request`: the save came from outside the plugin (OBS's own Save Replay hotkey, the tray menu, or a Stream Deck button using the official OBS Studio plugin's "Save Replay Buffer" action). Bind a *Replay Buffer Pro: Save…* hotkey instead
+- `skipped reason=save-full-buffer`: a Save Replay Buffer click, intentionally untrimmed
+- `failed reason=output-too-long`: the encoder keyframe interval is too long for the requested clip length. Set Settings → Output → Keyframe Interval to 2 seconds
+- `failed reason=open-input-failed`: another process was holding the file. Try disabling "Automatically remux to mp4"; antivirus and cloud-sync folders do the same
+- Any other failure: check disk space and write permissions in the output directory
+- A failed trim always leaves the original full-length clip in place
 
 **Button Disabled**
 - Check if your buffer length is long enough for that clip duration

--- a/reference/architecture/replay-buffer-flow.md
+++ b/reference/architecture/replay-buffer-flow.md
@@ -6,49 +6,107 @@ This document explains how the plugin saves replay buffer content and trims it t
 - Trigger replay buffer saves through OBS frontend APIs.
 - Track the requested duration for the saved file.
 - Trim the saved file to the last N seconds using FFmpeg (libavformat).
+- Report the outcome of every save, so an untrimmed clip is diagnosable after the fact.
+
+## Correlating requests with saved files
+
+OBS provides no way to tie a save request to the file it eventually produces. `obs_frontend_replay_buffer_save()` only arms a timestamp inside the replay buffer output; the mux starts on the next encoded packet and the `saved` event fires when the file is complete, which can be seconds later.
+
+`ReplayBufferManager` therefore keeps a FIFO of pending requests and matches them to saved events in order:
+
+- Each request records its duration and the time it was made. A duration of `0` is an explicit "do not trim" marker used by Save Replay Buffer.
+- Requests expire after `Config::TRIM_REQUEST_TIMEOUT_MS`. OBS silently drops a save when the encoders are paused or the output is inactive, and without expiry that orphaned duration would later be applied to an unrelated clip.
+- Requests made within `Config::TRIM_REQUEST_COALESCE_MS` of each other are collapsed into one, because OBS tracks a single pending save timestamp and produces only one file for presses that close together.
+- A saved event with nothing pending came from outside the plugin (OBS's own Save Replay hotkey, the tray item, obs-websocket). It is logged and left alone.
 
 ## Save segment flow
 1. User clicks a duration button or hotkey.
 2. `ReplayBufferManager::saveSegment(duration, parent)` validates:
    - Replay buffer is active.
    - `duration <= currentBufferLength` from `SettingsManager`.
-3. If valid, `pendingSaveDuration` is set and `obs_frontend_replay_buffer_save()` is called.
+3. If valid, the request is queued and `obs_frontend_replay_buffer_save()` is called.
 4. OBS emits `OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED`.
-5. The dock calls `handleReplayBufferSaved()`:
-   - Retrieves the saved path via `obs_frontend_get_last_replay()`.
-   - Copies the path, frees the OBS-allocated buffer, and trims in a background thread.
-   - Clears `pendingSaveDuration`.
+5. `Plugin::handleReplayBufferSaved()` reads the path via `obs_frontend_get_last_replay()` and hands it to `ReplayBufferManager::handleSaveCompleted(...)`.
+6. The manager pops the matching request and queues a trim job for its worker thread.
 
 ## Save full buffer flow
-1. User clicks “Save Replay Buffer”.
+1. User clicks "Save Replay Buffer".
 2. `ReplayBufferManager::saveFullBuffer(...)` checks buffer activity.
-3. If active, it calls `obs_frontend_replay_buffer_save()` and does not set a pending duration.
-4. When OBS signals a saved replay, no trim is performed because the pending duration is 0.
+3. If active, it queues a `0` request and calls `obs_frontend_replay_buffer_save()`.
+4. The saved event consumes that marker and skips trimming. Queueing the marker rather than nothing is what stops the save from inheriting a stale duration from an earlier request.
 
 ## Trimming details
-- `ReplayBufferManager::trimReplayBuffer(...)`:
-  - Builds output path by inserting `_trimmed` before the extension.
-  - Calls `VideoTrimmer::trimToLastSeconds(...)`.
-  - Deletes the original file with `os_unlink(...)` on success.
+
+Trims run on a single worker thread owned by `ReplayBufferManager`, joined in its destructor. One trim runs at a time, and none can outlive the manager.
+
+`processTrimJob(...)` commits in stages so a failure never costs the user their clip:
+
+1. Trim into `<name>.rbp-partial.<ext>`, never straight to the final name.
+2. Verify the result with `VideoTrimmer::getVideoDuration(...)`. The output is rejected if it is unreadable, shorter than `Config::TRIM_MIN_DURATION_RATIO` of what was achievable, or longer than both `Config::TRIM_MAX_DURATION_RATIO` and `Config::TRIM_MAX_DURATION_SLACK_SECONDS` allow. The upper bound is deliberately loose because keyframe alignment legitimately makes clips longer, never shorter.
+3. Rename the partial to `<name>_trimmed.<ext>`.
+4. Delete the original, retrying while another process still holds it.
+
+Any failure deletes the partial and leaves the original untouched.
+
+### Cut point selection
+
+`VideoTrimmer::trimToLastSeconds(...)` seeks backwards to the requested start, which lands on the closest keyframe at or before it, and takes the first key video packet from there as the cut point. Timestamps are compared as DTS, which is monotonic; comparing PTS lets a reordered B-frame end the search early and drag the cut back by a whole GOP.
+
+The cut can only ever land at or before the request, so a clip is never shorter than asked and can be longer by up to one GOP. Drift beyond `Config::TRIM_KEYFRAME_TOLERANCE_SECONDS` is logged as a warning naming the encoder keyframe interval as the cause.
+
+### Contention for the saved file
+
+`OBSBasic::ReplayBufferSaved()` calls `AutoRemux(path)` immediately after firing the saved event, so when "Automatically remux to mp4" is enabled OBS is reading the same file the plugin is about to trim and delete. Antivirus and cloud-sync clients do the same to any newly written file. Both the input open and the original delete retry with backoff, and the AutoRemux setting is logged when a trim starts so the interaction is visible in the log.
+
+## Diagnostics
+
+Every `OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED` produces exactly one verdict line, prefixed `TRIM VERDICT`:
+
+```
+[ReplayBufferPro] TRIM VERDICT: ok file='...' requested=30s actual=31.2s source=540.0s cut_at=508.8s elapsed=1.4s
+[ReplayBufferPro] TRIM VERDICT: skipped reason=no-pending-request file='...'
+[ReplayBufferPro] TRIM VERDICT: skipped reason=save-full-buffer file='...'
+[ReplayBufferPro] TRIM VERDICT: failed reason=open-input-failed detail='...' file='...' requested=30s elapsed=2.1s original-kept
+```
+
+Grepping an OBS log for `TRIM VERDICT` gives a complete per-save accounting. The `reason` field names the cause:
+
+| reason | meaning |
+| --- | --- |
+| `no-pending-request` | The save was triggered outside the plugin, so it was not trimmed |
+| `save-full-buffer` | Save Replay Buffer, intentionally untrimmed |
+| `no-saved-path` | OBS reported a save but no path |
+| `open-input-failed` | The saved file could not be opened, even after retries |
+| `output-too-long` | The cut point collapsed; the clip would have been near full length |
+| `output-too-short` / `output-unreadable` | The written clip did not survive verification |
+| `no-packets-written` | Nothing was copied; writing would have produced an empty clip |
+| `rename-failed` | The verified clip could not take its final name |
+
+Successes and failures also surface briefly in the OBS status bar via `StatusReporter`.
 
 ## Third-party compatibility
 - [Smart Replay Mover](https://github.com/SlonickLab/Smart-Replay-Mover) (SlonickLab) is a third-party OBS Lua script that waits for this plugin to finish trimming, then moves the final `_trimmed` file into per-game folders. See [issue #23](https://github.com/JoshuaPotter/replay-buffer-pro/issues/23).
+- The `_trimmed` suffix and the deletion of the original are unchanged. Trims are now written to a `.rbp-partial.<ext>` scratch file and renamed into place, so the `_trimmed` file appears atomically and is complete the moment it exists — previously a watcher could observe it partially written.
 - If the `_trimmed` suffix, the original-file deletion, or the timing of when the final file appears changes, open an issue at https://github.com/SlonickLab/Smart-Replay-Mover so they can update their compatibility handling.
 
 ## Error handling
 - UI warnings show when the replay buffer is inactive or the requested duration is too long.
-- Trimming errors are logged via `Logger::error(...)` but do not raise UI alerts.
-- If no saved replay path is returned, trimming is skipped.
+- A failed trim leaves the original clip in place, logs a `failed` verdict naming the reason, and shows a status bar message.
+- If no saved replay path is returned, trimming is skipped and logged.
 
 ## Key classes and functions
 - `ReplayBufferManager::saveSegment(...)`
 - `ReplayBufferManager::saveFullBuffer(...)`
-- `ReplayBufferManager::getPendingSaveDuration()`
-- `ReplayBufferManager::trimReplayBuffer(...)`
+- `ReplayBufferManager::handleSaveCompleted(...)`
+- `ReplayBufferManager::processTrimJob(...)`
+- `ReplayBufferManager::verifyTrimmedOutput(...)`
 - `VideoTrimmer::trimToLastSeconds(...)`
+- `StatusReporter::showMessage(...)`
 
 ## Related code
 - `src/managers/replay-buffer-manager.hpp`
 - `src/managers/replay-buffer-manager.cpp`
 - `src/utils/video-trimmer.hpp`
 - `src/utils/video-trimmer.cpp`
+- `src/utils/status-reporter.hpp`
+- `src/utils/status-reporter.cpp`

--- a/reference/architecture/utilities.md
+++ b/reference/architecture/utilities.md
@@ -16,16 +16,34 @@ This document covers shared utilities used across the plugin.
 - `duration-format` formats localized duration labels (seconds/minutes/hours).
 - Used for save button labels and hotkey descriptions.
 
+## Status bar messages
+- `StatusReporter::showMessage(text, timeoutMs)` posts transient text to the OBS main window status bar.
+- It reaches the bar through `obs_frontend_get_main_window()` and marshals onto the Qt main thread, so it is safe to call from the trim worker thread.
+- It does nothing when the main window is unavailable, which is the case during shutdown.
+
 ## Video trimming (FFmpeg libavformat)
 `VideoTrimmer` trims a saved replay file down to the last N seconds using stream copy (no re-encoding). It follows this sequence:
-1. Open the input file and find stream info.
+1. Open the input file, retrying with backoff while another process still holds it, and find stream info.
 2. Determine total duration from container or stream durations.
 3. Calculate start time: `max(0, totalDuration - durationSeconds)`.
 4. Create output format context and mirror input streams.
-5. Seek to the start time and locate a keyframe at or after the target.
-6. Copy packets from the effective start time to the end.
+5. Seek backwards to the start time and take the first key video packet as the cut point.
+6. Copy packets from the cut point to the end.
 7. Rescale timestamps per stream so output starts at 0.
 8. Write trailer and close contexts.
+
+It returns a `TrimResult` carrying the source duration, requested start, actual cut point and packet count, which the caller uses both to verify the output and to build its log verdict.
+
+### Cut point selection
+- `AVSEEK_FLAG_BACKWARD` already lands on the closest keyframe at or before the target, so the first key packet after the seek is the cut point. If seeking is unavailable, the scan falls back to tracking the last keyframe at or before the target.
+- Timestamps are compared as **DTS**, which is monotonic. Comparing PTS lets a reordered B-frame end the search early and move the cut back by a whole GOP.
+- Because the cut only ever lands at or before the request, output is never shorter than asked and can be up to one GOP longer. Drift past `Config::TRIM_KEYFRAME_TOLERANCE_SECONDS` is logged as a warning.
+
+### Timestamp handling
+- All streams are rebased by the same offset so they stay in sync.
+- Filtering on DTS keeps the shifted timestamps non-negative, since `DTS <= PTS` holds for every valid packet.
+- A packet missing only one timestamp is passed through; the muxer infers the rest. Substituting PTS for a missing DTS reorders B-frames badly enough to fail the write.
+- A packet missing both timestamps is stepped on from the previous packet in that stream rather than dropped, which would otherwise punch a hole in the clip.
 
 ### Stream setup details
 - `setupOutputStreams(...)` copies codec parameters and metadata.
@@ -33,8 +51,9 @@ This document covers shared utilities used across the plugin.
 - `codec_tag` is cleared to avoid container mismatch issues.
 
 ### Error handling
-- Errors are logged and return `false` to the caller.
-- If any step fails, the output context is closed and the call ends.
+- Failures return a `TrimResult` with `success == false` and a short stable `reason` token, plus the libav error text in `detail`.
+- If any step fails, the input and output contexts are closed and the partial output is left for the caller to delete.
+- Copying zero packets is treated as a failure (`no-packets-written`) rather than writing a valid but empty file, which would otherwise cost the caller the original.
 
 ## Related code
 - `src/utils/obs-utils.hpp`
@@ -42,5 +61,7 @@ This document covers shared utilities used across the plugin.
 - `src/utils/duration-format.hpp`
 - `src/utils/duration-format.cpp`
 - `src/utils/logger.hpp`
+- `src/utils/status-reporter.hpp`
+- `src/utils/status-reporter.cpp`
 - `src/utils/video-trimmer.hpp`
 - `src/utils/video-trimmer.cpp`

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -30,8 +30,27 @@ namespace ReplayBufferPro
     constexpr int SETTINGS_MONITOR_INTERVAL = 1000; // 1 second
     constexpr int SLIDER_DEBOUNCE_INTERVAL = 800;   // 800 milliseconds
 
+    // Trim request correlation
+    constexpr int TRIM_REQUEST_TIMEOUT_MS = 30000;  // Drop a request OBS never honored
+    constexpr int TRIM_REQUEST_COALESCE_MS = 250;   // Presses this close yield one OBS file
+
+    // Trim retry behavior. OBS starts AutoRemux on the same file the moment it fires
+    // the saved event, so the first open or unlink can lose a race with it.
+    constexpr int TRIM_OPEN_RETRY_COUNT = 5;
+    constexpr int TRIM_OPEN_RETRY_DELAY_MS = 250; // Backs off from here
+    constexpr int TRIM_UNLINK_RETRY_COUNT = 5;
+    constexpr int TRIM_UNLINK_RETRY_DELAY_MS = 200;
+
+    // Trim output validation
+    constexpr double TRIM_KEYFRAME_TOLERANCE_SECONDS = 10.0; // Warn past this cut-point drift
+    constexpr double TRIM_MIN_DURATION_RATIO = 0.5;          // Below this the output is truncated
+    constexpr double TRIM_MAX_DURATION_RATIO = 2.0;          // Above this AND the slack, it collapsed
+    constexpr double TRIM_MAX_DURATION_SLACK_SECONDS = 15.0;
+
     // File paths
     constexpr const char *TEMP_FILE_SUFFIX = "tmp";
     constexpr const char *BACKUP_FILE_SUFFIX = "bak";
+    constexpr const char *TRIM_PARTIAL_SUFFIX = ".rbp-partial";
+    constexpr const char *TRIM_OUTPUT_SUFFIX = "_trimmed";
   } // namespace Config
 } // namespace ReplayBufferPro

--- a/src/managers/replay-buffer-manager.cpp
+++ b/src/managers/replay-buffer-manager.cpp
@@ -143,13 +143,9 @@ namespace ReplayBufferPro
   // REQUEST TRACKING
   //=============================================================================
 
-  void ReplayBufferManager::enqueueRequest(int duration)
+  void ReplayBufferManager::expireStaleRequestsLocked(uint64_t now)
   {
-    const uint64_t now = os_gettime_ns();
     const uint64_t timeoutNs = static_cast<uint64_t>(Config::TRIM_REQUEST_TIMEOUT_MS) * 1000000ULL;
-    const uint64_t coalesceNs = static_cast<uint64_t>(Config::TRIM_REQUEST_COALESCE_MS) * 1000000ULL;
-
-    std::lock_guard<std::mutex> lock(pendingMutex);
 
     while (!pendingSaves.empty() && now - pendingSaves.front().requestedAtNs > timeoutNs)
     {
@@ -157,6 +153,16 @@ namespace ReplayBufferPro
                       pendingSaves.front().duration);
       pendingSaves.pop_front();
     }
+  }
+
+  void ReplayBufferManager::enqueueRequest(int duration)
+  {
+    const uint64_t now = os_gettime_ns();
+    const uint64_t coalesceNs = static_cast<uint64_t>(Config::TRIM_REQUEST_COALESCE_MS) * 1000000ULL;
+
+    std::lock_guard<std::mutex> lock(pendingMutex);
+
+    expireStaleRequestsLocked(now);
 
     // OBS tracks a single pending save timestamp, so two requests landing inside
     // one frame interval produce only one file. Collapsing them here keeps the
@@ -176,16 +182,10 @@ namespace ReplayBufferPro
   std::optional<ReplayBufferManager::PendingSave> ReplayBufferManager::takeNextPendingSave()
   {
     const uint64_t now = os_gettime_ns();
-    const uint64_t timeoutNs = static_cast<uint64_t>(Config::TRIM_REQUEST_TIMEOUT_MS) * 1000000ULL;
 
     std::lock_guard<std::mutex> lock(pendingMutex);
 
-    while (!pendingSaves.empty() && now - pendingSaves.front().requestedAtNs > timeoutNs)
-    {
-      Logger::warning("Discarding save request for %ds that OBS never completed",
-                      pendingSaves.front().duration);
-      pendingSaves.pop_front();
-    }
+    expireStaleRequestsLocked(now);
 
     if (pendingSaves.empty())
     {

--- a/src/managers/replay-buffer-manager.cpp
+++ b/src/managers/replay-buffer-manager.cpp
@@ -5,25 +5,83 @@
 
 #include "managers/replay-buffer-manager.hpp"
 #include "managers/settings-manager.hpp"
+#include "config/config.hpp"
+#include "utils/duration-format.hpp"
 #include "utils/logger.hpp"
+#include "utils/status-reporter.hpp"
 #include "utils/video-trimmer.hpp"
 
 // OBS includes
+#include <util/config-file.h>
 #include <util/platform.h>
 
 // Qt includes
 #include <QMessageBox>
 #include <QString>
 
+// STL includes
+#include <algorithm>
+#include <chrono>
+
 namespace ReplayBufferPro
 {
+  namespace
+  {
+    /**
+     * @brief Splits a path into everything before the extension and the extension
+     *
+     * Only considers a dot that falls inside the file name, so a directory such
+     * as "C:/clips.old/replay" is not mistaken for an extension.
+     */
+    void splitExtension(const std::string &path, std::string *stem, std::string *extension)
+    {
+      const size_t separator = path.find_last_of("/\\");
+      const size_t nameStart = (separator == std::string::npos) ? 0 : separator + 1;
+      const size_t dot = path.find_last_of('.');
+
+      if (dot != std::string::npos && dot > nameStart)
+      {
+        *stem = path.substr(0, dot);
+        *extension = path.substr(dot);
+      }
+      else
+      {
+        *stem = path;
+        extension->clear();
+      }
+    }
+
+    /**
+     * @brief Quotes a path for a log line
+     */
+    std::string quoted(const std::string &value)
+    {
+      return "'" + value + "'";
+    }
+  } // namespace
+
   //=============================================================================
   // CONSTRUCTORS & DESTRUCTOR
   //=============================================================================
 
   ReplayBufferManager::ReplayBufferManager(QObject *parent)
-      : QObject(parent), pendingSaveDuration(0)
+      : QObject(parent)
   {
+    worker = std::thread([this]() { workerLoop(); });
+  }
+
+  ReplayBufferManager::~ReplayBufferManager()
+  {
+    {
+      std::lock_guard<std::mutex> lock(jobMutex);
+      stopping = true;
+    }
+    jobCv.notify_all();
+
+    if (worker.joinable())
+    {
+      worker.join();
+    }
   }
 
   //=============================================================================
@@ -57,7 +115,7 @@ namespace ReplayBufferPro
       return false;
     }
 
-    pendingSaveDuration = duration; // Store the duration for the save completion handler
+    enqueueRequest(duration);
     obs_frontend_replay_buffer_save();
     return true;
   }
@@ -66,6 +124,10 @@ namespace ReplayBufferPro
   {
     if (obs_frontend_replay_buffer_active())
     {
+      // Queue an explicit do-not-trim marker rather than saving with nothing
+      // pending, so this save consumes its own slot instead of inheriting a
+      // duration left over from an earlier request OBS never honored.
+      enqueueRequest(0);
       obs_frontend_replay_buffer_save();
       return true;
     }
@@ -77,64 +139,356 @@ namespace ReplayBufferPro
     return false;
   }
 
-  void ReplayBufferManager::setPendingSaveDuration(int duration)
-  {
-    pendingSaveDuration = duration;
-  }
-
-  int ReplayBufferManager::getPendingSaveDuration() const
-  {
-    return pendingSaveDuration;
-  }
-
-  void ReplayBufferManager::clearPendingSaveDuration()
-  {
-    pendingSaveDuration = 0;
-  }
-
   //=============================================================================
-  // REPLAY PROCESSING
+  // REQUEST TRACKING
   //=============================================================================
 
-  std::string ReplayBufferManager::getTrimmedOutputPath(const char *sourcePath)
+  void ReplayBufferManager::enqueueRequest(int duration)
   {
-    std::string path(sourcePath);
-    size_t dot = path.find_last_of('.');
-    if (dot != std::string::npos)
+    const uint64_t now = os_gettime_ns();
+    const uint64_t timeoutNs = static_cast<uint64_t>(Config::TRIM_REQUEST_TIMEOUT_MS) * 1000000ULL;
+    const uint64_t coalesceNs = static_cast<uint64_t>(Config::TRIM_REQUEST_COALESCE_MS) * 1000000ULL;
+
+    std::lock_guard<std::mutex> lock(pendingMutex);
+
+    while (!pendingSaves.empty() && now - pendingSaves.front().requestedAtNs > timeoutNs)
     {
-      path.insert(dot, "_trimmed");
+      Logger::warning("Discarding save request for %ds that OBS never completed",
+                      pendingSaves.front().duration);
+      pendingSaves.pop_front();
+    }
+
+    // OBS tracks a single pending save timestamp, so two requests landing inside
+    // one frame interval produce only one file. Collapsing them here keeps the
+    // queue from running permanently one ahead of the saved events.
+    if (!pendingSaves.empty() && now - pendingSaves.back().requestedAtNs < coalesceNs)
+    {
+      Logger::info("Coalescing save request for %ds into the previous one for %ds",
+                   duration, pendingSaves.back().duration);
+      pendingSaves.back().duration = duration;
+      pendingSaves.back().requestedAtNs = now;
+      return;
+    }
+
+    pendingSaves.push_back(PendingSave{duration, now});
+  }
+
+  std::optional<ReplayBufferManager::PendingSave> ReplayBufferManager::takeNextPendingSave()
+  {
+    const uint64_t now = os_gettime_ns();
+    const uint64_t timeoutNs = static_cast<uint64_t>(Config::TRIM_REQUEST_TIMEOUT_MS) * 1000000ULL;
+
+    std::lock_guard<std::mutex> lock(pendingMutex);
+
+    while (!pendingSaves.empty() && now - pendingSaves.front().requestedAtNs > timeoutNs)
+    {
+      Logger::warning("Discarding save request for %ds that OBS never completed",
+                      pendingSaves.front().duration);
+      pendingSaves.pop_front();
+    }
+
+    if (pendingSaves.empty())
+    {
+      return std::nullopt;
+    }
+
+    PendingSave next = pendingSaves.front();
+    pendingSaves.pop_front();
+    return next;
+  }
+
+  //=============================================================================
+  // SAVE COMPLETION
+  //=============================================================================
+
+  void ReplayBufferManager::handleSaveCompleted(const std::string &savedPath)
+  {
+    std::optional<PendingSave> pending = takeNextPendingSave();
+
+    if (!pending.has_value())
+    {
+      // OBS's own Save Replay hotkey, the tray item and obs-websocket all reach
+      // here. Those saves are not ours to trim, but saying so explicitly is what
+      // turns "my clip wasn't trimmed" into an answerable question.
+      reportVerdict("skipped",
+                    "reason=no-pending-request file=" + quoted(savedPath),
+                    QString(), false);
+      return;
+    }
+
+    if (pending->duration <= 0)
+    {
+      reportVerdict("skipped",
+                    "reason=save-full-buffer file=" + quoted(savedPath),
+                    QString(), false);
+      return;
+    }
+
+    if (savedPath.empty())
+    {
+      reportVerdict("failed",
+                    "reason=no-saved-path requested=" + std::to_string(pending->duration) + "s",
+                    QString(obs_module_text("StatusTrimFailed")).arg("no saved path"),
+                    true);
+      return;
+    }
+
+    // AutoRemux runs against this same file the instant OBS fires the saved
+    // event, so note it up front when a trim later loses a race for the file.
+    if (config_t *profile = obs_frontend_get_profile_config())
+    {
+      if (config_get_bool(profile, "Video", "AutoRemux"))
+      {
+        Logger::warning("OBS automatic remuxing is enabled; it competes with trimming "
+                        "for the same file and can delay or block it");
+      }
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(jobMutex);
+      if (stopping)
+      {
+        return;
+      }
+      jobQueue.push_back(TrimJob{savedPath, pending->duration});
+    }
+    jobCv.notify_one();
+  }
+
+  //=============================================================================
+  // TRIMMING
+  //=============================================================================
+
+  void ReplayBufferManager::workerLoop()
+  {
+    for (;;)
+    {
+      TrimJob job;
+
+      {
+        std::unique_lock<std::mutex> lock(jobMutex);
+        jobCv.wait(lock, [this]() { return stopping || !jobQueue.empty(); });
+
+        if (stopping)
+        {
+          if (!jobQueue.empty())
+          {
+            Logger::warning("Abandoning %zu queued trim(s) during shutdown; "
+                            "those clips keep their full length",
+                            jobQueue.size());
+            jobQueue.clear();
+          }
+          return;
+        }
+
+        job = std::move(jobQueue.front());
+        jobQueue.pop_front();
+      }
+
+      processTrimJob(job);
+    }
+  }
+
+  void ReplayBufferManager::processTrimJob(const TrimJob &job)
+  {
+    const auto startedAt = std::chrono::steady_clock::now();
+
+    const std::string partialPath = getPartialOutputPath(job.sourcePath);
+    const std::string finalPath = getTrimmedOutputPath(job.sourcePath);
+    const std::string requested = std::to_string(job.duration) + "s";
+
+    auto elapsedSeconds = [&startedAt]() {
+      return std::chrono::duration<double>(std::chrono::steady_clock::now() - startedAt).count();
+    };
+
+    auto fail = [&](const std::string &reason, const std::string &detail) {
+      removeFileWithRetry(partialPath);
+
+      std::string line = "reason=" + reason;
+      if (!detail.empty())
+      {
+        line += " detail=" + quoted(detail);
+      }
+      line += " file=" + quoted(job.sourcePath) +
+              " requested=" + requested +
+              " elapsed=" + QString::number(elapsedSeconds(), 'f', 1).toStdString() + "s" +
+              " original-kept";
+
+      reportVerdict("failed", line,
+                    QString(obs_module_text("StatusTrimFailed"))
+                        .arg(QString::fromStdString(reason)),
+                    true);
+    };
+
+    Logger::info("Trimming replay buffer save to %d seconds", job.duration);
+
+    // A partial left by an earlier crash would otherwise fail the rename
+    if (os_file_exists(partialPath.c_str()))
+    {
+      Logger::warning("Removing leftover partial file: %s", partialPath.c_str());
+      removeFileWithRetry(partialPath);
+    }
+
+    const TrimResult trim = VideoTrimmer::trimToLastSeconds(job.sourcePath, partialPath, job.duration);
+    if (!trim.success)
+    {
+      fail(trim.reason, trim.detail);
+      return;
+    }
+
+    // Confirm the file on disk is the length that was asked for. Without this a
+    // cut point that collapsed toward the start of the buffer would be reported
+    // as a success and the full-length original deleted in its favour.
+    double actualDuration = 0.0;
+    std::string verifyReason;
+    if (!verifyTrimmedOutput(partialPath, job.duration, trim.sourceDuration,
+                             &actualDuration, &verifyReason))
+    {
+      Logger::error("Trimmed output failed verification (%s): %.2fs from a %.2fs source, "
+                    "cut at %.2fs",
+                    verifyReason.c_str(), actualDuration, trim.sourceDuration, trim.cutAt);
+      fail(verifyReason, "measured " + QString::number(actualDuration, 'f', 1).toStdString() + "s");
+      return;
+    }
+
+    // Only now is the trim allowed to take the final name, so nothing watching
+    // the recordings folder ever sees a half-written clip.
+    if (os_file_exists(finalPath.c_str()))
+    {
+      Logger::warning("Replacing existing file: %s", finalPath.c_str());
+      removeFileWithRetry(finalPath);
+    }
+
+    if (os_rename(partialPath.c_str(), finalPath.c_str()) != 0)
+    {
+      fail("rename-failed", "could not rename to " + finalPath);
+      return;
+    }
+
+    std::string line = "file=" + quoted(finalPath) +
+                       " requested=" + requested +
+                       " actual=" + QString::number(actualDuration, 'f', 1).toStdString() + "s" +
+                       " source=" + QString::number(trim.sourceDuration, 'f', 1).toStdString() + "s" +
+                       " cut_at=" + QString::number(trim.cutAt, 'f', 1).toStdString() + "s";
+
+    if (!removeFileWithRetry(job.sourcePath))
+    {
+      // The clip is correct, but the untrimmed original is still sitting next to
+      // it and the user will notice. Say so rather than reporting a clean success.
+      Logger::warning("Could not delete the original file: %s", job.sourcePath.c_str());
+      line += " original-not-deleted=" + quoted(job.sourcePath);
+    }
+
+    line += " elapsed=" + QString::number(elapsedSeconds(), 'f', 1).toStdString() + "s";
+
+    reportVerdict("ok", line,
+                  QString(obs_module_text("StatusTrimSuccess"))
+                      .arg(formatDurationValue(job.duration)),
+                  false);
+  }
+
+  bool ReplayBufferManager::verifyTrimmedOutput(const std::string &outputPath, int duration,
+                                                double sourceDuration, double *actualDuration,
+                                                std::string *reason)
+  {
+    const double actual = VideoTrimmer::getVideoDuration(outputPath);
+    *actualDuration = actual;
+
+    if (actual <= 0.0)
+    {
+      *reason = "output-unreadable";
+      return false;
+    }
+
+    // A buffer holding less than the requested duration legitimately yields a
+    // shorter clip, so measure against whichever is smaller.
+    const double expected = (sourceDuration > 0.0)
+                                ? std::min(static_cast<double>(duration), sourceDuration)
+                                : static_cast<double>(duration);
+
+    if (actual < expected * Config::TRIM_MIN_DURATION_RATIO)
+    {
+      *reason = "output-too-short";
+      return false;
+    }
+
+    // Keyframe alignment only ever makes a clip longer, and by at most one GOP,
+    // so the bar here is deliberately generous. Tripping it means the cut point
+    // collapsed and the "trim" is effectively a copy of the whole buffer.
+    if (actual > expected * Config::TRIM_MAX_DURATION_RATIO &&
+        actual > expected + Config::TRIM_MAX_DURATION_SLACK_SECONDS)
+    {
+      *reason = "output-too-long";
+      return false;
+    }
+
+    return true;
+  }
+
+  //=============================================================================
+  // HELPER METHODS
+  //=============================================================================
+
+  std::string ReplayBufferManager::getTrimmedOutputPath(const std::string &sourcePath)
+  {
+    std::string stem;
+    std::string extension;
+    splitExtension(sourcePath, &stem, &extension);
+    return stem + Config::TRIM_OUTPUT_SUFFIX + extension;
+  }
+
+  std::string ReplayBufferManager::getPartialOutputPath(const std::string &sourcePath)
+  {
+    std::string stem;
+    std::string extension;
+    splitExtension(sourcePath, &stem, &extension);
+    // Keep the original extension last so libavformat still picks the right muxer
+    return stem + Config::TRIM_PARTIAL_SUFFIX + extension;
+  }
+
+  bool ReplayBufferManager::removeFileWithRetry(const std::string &path)
+  {
+    if (!os_file_exists(path.c_str()))
+    {
+      return true;
+    }
+
+    int delayMs = Config::TRIM_UNLINK_RETRY_DELAY_MS;
+
+    for (int attempt = 1; attempt <= Config::TRIM_UNLINK_RETRY_COUNT; attempt++)
+    {
+      if (os_unlink(path.c_str()) == 0 || !os_file_exists(path.c_str()))
+      {
+        return true;
+      }
+
+      if (attempt < Config::TRIM_UNLINK_RETRY_COUNT)
+      {
+        os_sleep_ms(delayMs);
+        delayMs *= 2;
+      }
+    }
+
+    return !os_file_exists(path.c_str());
+  }
+
+  void ReplayBufferManager::reportVerdict(const char *outcome, const std::string &detail,
+                                          const QString &statusMessage, bool isFailure)
+  {
+    if (isFailure)
+    {
+      Logger::error("TRIM VERDICT: %s %s", outcome, detail.c_str());
     }
     else
     {
-      path += "_trimmed";
+      Logger::info("TRIM VERDICT: %s %s", outcome, detail.c_str());
     }
 
-    return path;
-  }
-
-
-  void ReplayBufferManager::trimReplayBuffer(const char *sourcePath, int duration)
-  {
-    try
+    if (!statusMessage.isEmpty())
     {
-      Logger::info("Trimming replay buffer save to %d seconds", duration);
-
-      std::string outputPath = getTrimmedOutputPath(sourcePath);
-
-      // Use libavformat instead of external FFmpeg binary
-      if (!VideoTrimmer::trimToLastSeconds(sourcePath, outputPath, duration))
-      {
-        throw std::runtime_error("Video trimming failed");
-      }
-
-      // Delete the original source file
-      os_unlink(sourcePath);
-
-      Logger::info("Successfully trimmed replay buffer to last %d seconds", duration);
-    }
-    catch (const std::exception &e)
-    {
-      Logger::error("Failed to trim replay: %s", e.what());
+      StatusReporter::showMessage(statusMessage,
+                                  isFailure ? StatusReporter::FAILURE_TIMEOUT_MS
+                                            : StatusReporter::DEFAULT_TIMEOUT_MS);
     }
   }
 

--- a/src/managers/replay-buffer-manager.hpp
+++ b/src/managers/replay-buffer-manager.hpp
@@ -12,9 +12,14 @@
 #include <obs-frontend-api.h>
 
 // STL includes
-#include <atomic>
-#include <string>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <optional>
 #include <stdexcept>
+#include <string>
+#include <thread>
 
 // Qt includes
 #include <QObject>
@@ -27,6 +32,11 @@ namespace ReplayBufferPro
 {
   /**
    * @brief Manages replay buffer operations including saving and trimming
+   *
+   * OBS gives no way to correlate a save request with the file it eventually
+   * produces, so requests are tracked in a FIFO and matched to saved events in
+   * order. Requests expire, which keeps one that OBS silently dropped from
+   * being applied to somebody else's clip later on.
    */
   class ReplayBufferManager : public QObject
   {
@@ -43,15 +53,15 @@ namespace ReplayBufferPro
     explicit ReplayBufferManager(QObject *parent = nullptr);
 
     /**
-     * @brief Destructor
+     * @brief Destructor, drains and joins the trim worker
      */
-    ~ReplayBufferManager() = default;
+    ~ReplayBufferManager();
 
     //=========================================================================
     // REPLAY BUFFER OPERATIONS
     //=========================================================================
     /**
-     * @brief Saves the replay buffer and set the duration for the pending trimming operation after save completes
+     * @brief Saves the replay buffer and queues a trim for the resulting file
      * @param duration Seconds to save
      * @param parent Parent widget for error messages
      * @return Success status
@@ -59,51 +69,131 @@ namespace ReplayBufferPro
     bool saveSegment(int duration, QWidget *parent = nullptr);
 
     /**
-     * @brief Saves the entire replay buffer
+     * @brief Saves the entire replay buffer without trimming
      * @param parent Parent widget for error messages
      * @return Success status
      */
     bool saveFullBuffer(QWidget *parent = nullptr);
 
     /**
-     * @brief Sets the pending save duration
-     * @param duration Duration in seconds
+     * @brief Matches a completed save to its request and schedules the trim
+     *
+     * Call from the Qt main thread when OBS reports a replay buffer save. Emits
+     * exactly one verdict line to the log for every save, whatever the outcome.
+     *
+     * @param savedPath Path OBS reported for the saved replay, may be empty
      */
-    void setPendingSaveDuration(int duration);
-
-    /**
-     * @brief Gets the pending save duration
-     * @return Duration in seconds
-     */
-    int getPendingSaveDuration() const;
-
-    /**
-     * @brief Clears the pending save duration
-     */
-    void clearPendingSaveDuration();
-
-    /**
-     * @brief Trims a replay buffer file, called after save completes
-     * @param sourcePath Source file path
-     * @param duration Duration in seconds
-     */
-    void trimReplayBuffer(const char *sourcePath, int duration);
+    void handleSaveCompleted(const std::string &savedPath);
 
   private:
     //=========================================================================
-    // MEMBER VARIABLES
+    // TYPES
     //=========================================================================
-    std::atomic<int> pendingSaveDuration; ///< Duration to save when buffer save completes (atomic for thread safety)
+    /**
+     * @brief A save this plugin asked for, awaiting its saved event
+     */
+    struct PendingSave
+    {
+      int duration;           ///< Seconds to keep, or 0 for an untrimmed full save
+      uint64_t requestedAtNs; ///< When it was requested, for expiry and coalescing
+    };
+
+    /**
+     * @brief A file waiting to be trimmed on the worker thread
+     */
+    struct TrimJob
+    {
+      std::string sourcePath;
+      int duration;
+    };
+
+    //=========================================================================
+    // REQUEST TRACKING
+    //=========================================================================
+    /**
+     * @brief Records a save request, expiring stale ones and coalescing bursts
+     * @param duration Seconds to keep, or 0 for an untrimmed full save
+     */
+    void enqueueRequest(int duration);
+
+    /**
+     * @brief Removes and returns the oldest live request, if any
+     * @return The request, or nullopt when the save did not come from this plugin
+     */
+    std::optional<PendingSave> takeNextPendingSave();
+
+    //=========================================================================
+    // TRIMMING
+    //=========================================================================
+    /**
+     * @brief Worker thread body, trims queued files one at a time
+     */
+    void workerLoop();
+
+    /**
+     * @brief Trims one file, verifies the result, then replaces the original
+     * @param job File and duration to process
+     */
+    void processTrimJob(const TrimJob &job);
+
+    /**
+     * @brief Checks a freshly written trim is plausibly the requested length
+     * @param outputPath File to probe
+     * @param duration Requested duration in seconds
+     * @param sourceDuration Duration of the input, which caps what is achievable
+     * @param actualDuration Receives the measured duration
+     * @param reason Receives a short failure token when the check fails
+     * @return true if the output should be kept
+     */
+    static bool verifyTrimmedOutput(const std::string &outputPath, int duration,
+                                    double sourceDuration, double *actualDuration,
+                                    std::string *reason);
 
     //=========================================================================
     // HELPER METHODS
     //=========================================================================
     /**
-     * @brief Gets output path for trimmed file
+     * @brief Gets the final path for a trimmed file
      * @param sourcePath Original file path
      * @return Trimmed file path
      */
-    std::string getTrimmedOutputPath(const char *sourcePath);
+    static std::string getTrimmedOutputPath(const std::string &sourcePath);
+
+    /**
+     * @brief Gets the scratch path a trim is written to before it is verified
+     * @param sourcePath Original file path
+     * @return Partial file path
+     */
+    static std::string getPartialOutputPath(const std::string &sourcePath);
+
+    /**
+     * @brief Deletes a file, retrying while another process still holds it
+     * @param path File to delete
+     * @return true if the file is gone
+     */
+    static bool removeFileWithRetry(const std::string &path);
+
+    /**
+     * @brief Logs the single verdict line for a save and shows a status message
+     * @param outcome One of "ok", "skipped" or "failed"
+     * @param detail Trailing key=value diagnostics for the log line
+     * @param statusMessage Status bar text, empty to show nothing
+     * @param isFailure Whether to use the longer failure status timeout
+     */
+    static void reportVerdict(const char *outcome, const std::string &detail,
+                              const QString &statusMessage, bool isFailure);
+
+    //=========================================================================
+    // MEMBER VARIABLES
+    //=========================================================================
+    std::mutex pendingMutex;              ///< Guards pendingSaves
+    std::deque<PendingSave> pendingSaves; ///< Requests awaiting a saved event
+
+    std::mutex jobMutex;             ///< Guards jobQueue and stopping
+    std::condition_variable jobCv;   ///< Signals the worker
+    std::deque<TrimJob> jobQueue;    ///< Files awaiting trimming
+    std::thread worker;              ///< Owned so trims cannot outlive the manager
+    bool stopping = false;           ///< Tells the worker to drain and exit
   };
 
 } // namespace ReplayBufferPro

--- a/src/managers/replay-buffer-manager.hpp
+++ b/src/managers/replay-buffer-manager.hpp
@@ -122,6 +122,13 @@ namespace ReplayBufferPro
      */
     std::optional<PendingSave> takeNextPendingSave();
 
+    /**
+     * @brief Pops requests OBS never honored off the front of pendingSaves
+     * @param now Current timestamp, as returned by os_gettime_ns()
+     * @pre pendingMutex is held by the caller
+     */
+    void expireStaleRequestsLocked(uint64_t now);
+
     //=========================================================================
     // TRIMMING
     //=========================================================================

--- a/src/plugin/plugin.cpp
+++ b/src/plugin/plugin.cpp
@@ -25,7 +25,6 @@
 #include <QPushButton>
 
 // STL includes
-#include <thread>
 #include <string>
 #include <vector>
 
@@ -214,28 +213,19 @@ namespace ReplayBufferPro
 		replayManager->saveSegment(duration, this);
 	}
 
-	void Plugin::handleReplayBufferSaved() 
+	void Plugin::handleReplayBufferSaved()
 	{
-		// Consume the pending duration immediately (before spawning the thread) so that a
-		// rapid second save event sees 0 and does not attempt to double-trim.
-		int duration = replayManager->getPendingSaveDuration();
-		if (duration > 0) {
-			replayManager->clearPendingSaveDuration();
+		std::string savedPath;
 
-			const char* savedPath = obs_frontend_get_last_replay();
-			if (savedPath) {
-				std::string pathCopy(savedPath);
-				bfree((void*)savedPath);
-
-				// Offload trimming to background thread to avoid blocking OBS event thread.
-				// duration is captured by value; clearPendingSaveDuration has already been
-				// called above so the next save event can proceed independently.
-				auto *manager = replayManager;
-				std::thread([manager, path = std::move(pathCopy), duration]() {
-					manager->trimReplayBuffer(path.c_str(), duration);
-				}).detach();
-			}
+		if (const char* path = obs_frontend_get_last_replay()) {
+			savedPath = path;
+			bfree((void*)path);
 		}
+
+		// The manager matches this to the request that produced it, logs a verdict
+		// either way, and hands any trimming off to its own worker thread so the
+		// OBS event thread is never blocked.
+		replayManager->handleSaveCompleted(savedPath);
 	}
 
 	void Plugin::handleCustomizeSaveButtons()

--- a/src/utils/status-reporter.cpp
+++ b/src/utils/status-reporter.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file status-reporter.cpp
+ * @brief Implementation of OBS status bar messaging
+ */
+
+#include "utils/status-reporter.hpp"
+
+// OBS includes
+#include <obs-frontend-api.h>
+
+// Qt includes
+#include <QMainWindow>
+#include <QMetaObject>
+#include <QStatusBar>
+#include <QTimer>
+
+namespace ReplayBufferPro
+{
+
+  void StatusReporter::showMessage(const QString &message, int timeoutMs)
+  {
+    auto *mainWindow = static_cast<QMainWindow *>(obs_frontend_get_main_window());
+    if (!mainWindow)
+    {
+      return;
+    }
+
+    // statusBar() creates the bar on demand and is not thread safe, so hop to
+    // the main thread even when the caller might already be on it.
+    QMetaObject::invokeMethod(
+        mainWindow,
+        [mainWindow, message, timeoutMs]()
+        {
+          if (QStatusBar *bar = mainWindow->statusBar())
+          {
+            bar->showMessage(message, timeoutMs);
+          }
+        },
+        Qt::QueuedConnection);
+  }
+
+} // namespace ReplayBufferPro

--- a/src/utils/status-reporter.hpp
+++ b/src/utils/status-reporter.hpp
@@ -1,0 +1,46 @@
+/**
+ * @file status-reporter.hpp
+ * @brief Posts transient messages to the OBS main window status bar
+ * @author Joshua Potter
+ * @copyright GPL v2 or later
+ *
+ * Trimming runs on a worker thread, so messages are marshalled onto the Qt
+ * main thread before touching the status bar.
+ */
+
+#pragma once
+
+// Qt includes
+#include <QString>
+
+namespace ReplayBufferPro
+{
+
+  /**
+   * @brief Shows short-lived messages in the OBS status bar
+   */
+  class StatusReporter
+  {
+  public:
+    /**
+     * @brief Default display time for a success message
+     */
+    static constexpr int DEFAULT_TIMEOUT_MS = 5000;
+
+    /**
+     * @brief Display time for a failure message, which is worth reading
+     */
+    static constexpr int FAILURE_TIMEOUT_MS = 10000;
+
+    /**
+     * @brief Shows a message in the OBS status bar
+     * @param message Text to display
+     * @param timeoutMs How long the message stays visible
+     *
+     * Safe to call from any thread. Does nothing if the OBS main window is
+     * unavailable, which is the case during shutdown.
+     */
+    static void showMessage(const QString &message, int timeoutMs = DEFAULT_TIMEOUT_MS);
+  };
+
+} // namespace ReplayBufferPro

--- a/src/utils/video-trimmer.cpp
+++ b/src/utils/video-trimmer.cpp
@@ -10,6 +10,7 @@
 
 #include "video-trimmer.hpp"
 #include "logger.hpp"
+#include "config/config.hpp"
 
 extern "C" {
 #include <libavformat/avformat.h>
@@ -20,6 +21,9 @@ extern "C" {
 #include <libavutil/error.h>
 #include <libavutil/log.h>
 }
+
+// OBS includes
+#include <util/platform.h>
 
 // Helper function to convert error codes to strings (MSVC-compatible)
 static std::string av_error_string(int errnum) {
@@ -34,40 +38,111 @@ static std::string av_error_string(int errnum) {
 
 namespace ReplayBufferPro {
 
-bool VideoTrimmer::trimToLastSeconds(const std::string& inputPath,
-                                   const std::string& outputPath,
-                                   int durationSeconds) {
+namespace {
+
+/**
+ * @brief Best available presentation time for a packet, in seconds
+ *
+ * Prefers DTS because it is monotonic across B-frames, which PTS is not.
+ * Returns false when the packet carries no usable timestamp at all.
+ */
+bool packetTimeSeconds(const AVPacket* packet, const AVStream* stream, double* out) {
+    if (packet->dts != AV_NOPTS_VALUE) {
+        *out = static_cast<double>(packet->dts) * av_q2d(stream->time_base);
+        return true;
+    }
+    if (packet->pts != AV_NOPTS_VALUE) {
+        *out = static_cast<double>(packet->pts) * av_q2d(stream->time_base);
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief Frees an output context and its AVIO handle
+ */
+void closeOutput(AVFormatContext** outputCtx) {
+    if (!*outputCtx) {
+        return;
+    }
+    if ((*outputCtx)->pb && !((*outputCtx)->oformat->flags & AVFMT_NOFILE)) {
+        avio_closep(&(*outputCtx)->pb);
+    }
+    avformat_free_context(*outputCtx);
+    *outputCtx = nullptr;
+}
+
+/**
+ * @brief Builds a failed TrimResult carrying the diagnostics gathered so far
+ */
+TrimResult failure(TrimResult result, std::string reason, std::string detail = {}) {
+    result.success = false;
+    result.reason = std::move(reason);
+    result.detail = std::move(detail);
+    return result;
+}
+
+} // namespace
+
+bool VideoTrimmer::openInputWithRetry(const std::string& inputPath,
+                                      AVFormatContext** inputCtx,
+                                      int* lastError) {
+    int delayMs = Config::TRIM_OPEN_RETRY_DELAY_MS;
+
+    for (int attempt = 1; attempt <= Config::TRIM_OPEN_RETRY_COUNT; attempt++) {
+        int ret = avformat_open_input(inputCtx, inputPath.c_str(), nullptr, nullptr);
+        if (ret >= 0) {
+            if (attempt > 1) {
+                Logger::info("Opened input on attempt %d of %d",
+                             attempt, Config::TRIM_OPEN_RETRY_COUNT);
+            }
+            return true;
+        }
+
+        *lastError = ret;
+        *inputCtx = nullptr;
+
+        if (attempt < Config::TRIM_OPEN_RETRY_COUNT) {
+            Logger::warning("Could not open '%s' (attempt %d of %d): %s - retrying in %dms",
+                            inputPath.c_str(), attempt, Config::TRIM_OPEN_RETRY_COUNT,
+                            av_error_string(ret).c_str(), delayMs);
+            os_sleep_ms(delayMs);
+            delayMs *= 2;
+        }
+    }
+
+    return false;
+}
+
+TrimResult VideoTrimmer::trimToLastSeconds(const std::string& inputPath,
+                                           const std::string& outputPath,
+                                           int durationSeconds) {
     initializeFFmpeg();
-    
+
+    TrimResult result;
     AVFormatContext* inputCtx = nullptr;
     AVFormatContext* outputCtx = nullptr;
-    
-    // Declare variables before any goto statements to avoid C2362 errors
-    int videoStreamIndex = -1;
-    int64_t keyframeTime = AV_NOPTS_VALUE;
-    int64_t seekTarget = 0;
-    double effectiveStartTime = 0.0;
-    
+
     try {
-        Logger::info("Starting video trim operation: %s -> %s (%d seconds)", 
+        Logger::info("Starting video trim operation: %s -> %s (%d seconds)",
                     inputPath.c_str(), outputPath.c_str(), durationSeconds);
-        
-        // Open input file
-        int ret = avformat_open_input(&inputCtx, inputPath.c_str(), nullptr, nullptr);
-        if (ret < 0) {
-            Logger::error("Could not open input file '%s': %s", 
-                         inputPath.c_str(), av_error_string(ret).c_str());
-            return false;
+
+        // Open input file, tolerating a file that is briefly locked
+        int openError = 0;
+        if (!openInputWithRetry(inputPath, &inputCtx, &openError)) {
+            Logger::error("Could not open input file '%s': %s",
+                         inputPath.c_str(), av_error_string(openError).c_str());
+            return failure(result, "open-input-failed", av_error_string(openError));
         }
-        
+
         // Retrieve stream information
-        ret = avformat_find_stream_info(inputCtx, nullptr);
+        int ret = avformat_find_stream_info(inputCtx, nullptr);
         if (ret < 0) {
             Logger::error("Could not find stream information: %s", av_error_string(ret).c_str());
             avformat_close_input(&inputCtx);
-            return false;
+            return failure(result, "stream-info-failed", av_error_string(ret));
         }
-        
+
         // Get total duration (prefer input context if available)
         double totalDuration = -1.0;
         if (inputCtx->duration != AV_NOPTS_VALUE) {
@@ -90,228 +165,292 @@ bool VideoTrimmer::trimToLastSeconds(const std::string& inputPath,
         if (totalDuration <= 0) {
             Logger::error("Could not determine video duration or file is empty");
             avformat_close_input(&inputCtx);
-            return false;
+            return failure(result, "duration-unavailable");
         }
-        
+
+        result.sourceDuration = totalDuration;
         Logger::info("Input video duration: %.2f seconds", totalDuration);
-        
+
         // Calculate start time (total duration - desired duration)
         // Ensure we don't go before the beginning of the file
         double startTime = std::max(0.0, totalDuration - durationSeconds);
-        
-        Logger::info("Trimming from %.2f seconds to end (%.2f seconds total)", 
+        result.requestedStart = startTime;
+
+        Logger::info("Trimming from %.2f seconds to end (%.2f seconds total)",
                     startTime, totalDuration - startTime);
-        
+
         // Create output context
         ret = avformat_alloc_output_context2(&outputCtx, nullptr, nullptr, outputPath.c_str());
         if (ret < 0) {
             Logger::error("Could not create output context: %s", av_error_string(ret).c_str());
             avformat_close_input(&inputCtx);
-            return false;
+            return failure(result, "output-context-failed", av_error_string(ret));
         }
-        
+
         // Setup output streams to match input
         if (!setupOutputStreams(inputCtx, outputCtx)) {
             Logger::error("Failed to setup output streams");
-            goto cleanup;
+            avformat_close_input(&inputCtx);
+            closeOutput(&outputCtx);
+            return failure(result, "output-streams-failed");
         }
-        
+
         // Open output file
         if (!(outputCtx->oformat->flags & AVFMT_NOFILE)) {
             ret = avio_open(&outputCtx->pb, outputPath.c_str(), AVIO_FLAG_WRITE);
             if (ret < 0) {
-                Logger::error("Could not open output file '%s': %s", 
+                Logger::error("Could not open output file '%s': %s",
                              outputPath.c_str(), av_error_string(ret).c_str());
-                goto cleanup;
+                avformat_close_input(&inputCtx);
+                closeOutput(&outputCtx);
+                return failure(result, "output-open-failed", av_error_string(ret));
             }
         }
-        
+
         // Write header
         ret = avformat_write_header(outputCtx, nullptr);
         if (ret < 0) {
             Logger::error("Error occurred when writing header: %s", av_error_string(ret).c_str());
-            goto cleanup;
+            avformat_close_input(&inputCtx);
+            closeOutput(&outputCtx);
+            return failure(result, "write-header-failed", av_error_string(ret));
         }
-        
+
         // Find the video stream
+        int videoStreamIndex = -1;
         for (unsigned int i = 0; i < inputCtx->nb_streams; i++) {
             if (inputCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-                videoStreamIndex = i;
+                videoStreamIndex = static_cast<int>(i);
                 break;
             }
         }
-        
-        // Seek to start time
-        seekTarget = static_cast<int64_t>(startTime * AV_TIME_BASE);
-        ret = av_seek_frame(inputCtx, -1, seekTarget, AVSEEK_FLAG_BACKWARD);
-        if (ret < 0) {
-            Logger::error("Error seeking to start time %.2f: %s", startTime, av_error_string(ret).c_str());
-            // Continue anyway - we might still be able to copy from the beginning
+
+        // Establish the cut point: the last keyframe at or before the requested
+        // start. Timestamps are compared as DTS, which is monotonic; comparing PTS
+        // here lets a reordered B-frame end the search early and drag the cut
+        // backwards by a whole GOP.
+        double cutTime = startTime;
+        auto seekToStart = [&](void) -> int {
+            if (videoStreamIndex >= 0) {
+                int64_t target = av_rescale_q(static_cast<int64_t>(startTime * AV_TIME_BASE),
+                                              AV_TIME_BASE_Q,
+                                              inputCtx->streams[videoStreamIndex]->time_base);
+                return av_seek_frame(inputCtx, videoStreamIndex, target, AVSEEK_FLAG_BACKWARD);
+            }
+            return av_seek_frame(inputCtx, -1, static_cast<int64_t>(startTime * AV_TIME_BASE),
+                                 AVSEEK_FLAG_BACKWARD);
+        };
+
+        ret = seekToStart();
+        const bool seekSucceeded = (ret >= 0);
+        if (!seekSucceeded) {
+            // Not fatal, but now the scan starts at the head of the file, so it has
+            // to keep going until it passes startTime rather than trusting the seek.
+            Logger::warning("Error seeking to start time %.2f: %s - scanning from the beginning",
+                            startTime, av_error_string(ret).c_str());
         }
-        
-        // Find the last keyframe at or before our desired start time.
-        // AVSEEK_FLAG_BACKWARD already positioned the stream at or before startTime, so we
-        // scan forward and keep updating keyframeTime for every key video frame we see until
-        // we pass startTime. The last recorded keyframe is the correct cut point.
-        effectiveStartTime = startTime;
+
         if (videoStreamIndex >= 0) {
             AVPacket* searchPacket = av_packet_alloc();
-            if (searchPacket) {
-                while (av_read_frame(inputCtx, searchPacket) >= 0) {
-                    if (searchPacket->stream_index == videoStreamIndex) {
-                        double packetTime = 0.0;
-                        if (searchPacket->pts != AV_NOPTS_VALUE) {
-                            packetTime = static_cast<double>(searchPacket->pts) *
-                                       av_q2d(inputCtx->streams[videoStreamIndex]->time_base);
-                        }
+            if (!searchPacket) {
+                Logger::error("Could not allocate search packet");
+                avformat_close_input(&inputCtx);
+                closeOutput(&outputCtx);
+                return failure(result, "packet-alloc-failed");
+            }
 
-                        if (searchPacket->flags & AV_PKT_FLAG_KEY) {
-                            // Keep tracking keyframes until we pass the cut point
-                            keyframeTime = searchPacket->pts;
-                            effectiveStartTime = packetTime;
-                        }
-
-                        // Once we've moved past startTime we have the last keyframe before it
-                        if (packetTime > startTime) {
-                            break;
-                        }
-                    }
+            bool foundKeyframe = false;
+            while (av_read_frame(inputCtx, searchPacket) >= 0) {
+                if (searchPacket->stream_index != videoStreamIndex) {
                     av_packet_unref(searchPacket);
+                    continue;
                 }
-                av_packet_free(&searchPacket);
 
-                // Seek exactly to the chosen keyframe so all streams start from there
-                if (keyframeTime != AV_NOPTS_VALUE) {
-                    int64_t keyframeSeekTarget = av_rescale_q(keyframeTime,
-                        inputCtx->streams[videoStreamIndex]->time_base, AV_TIME_BASE_Q);
-                    // Use AVSEEK_FLAG_ANY (exact) — we already know this is a keyframe position
-                    ret = av_seek_frame(inputCtx, -1, keyframeSeekTarget, AVSEEK_FLAG_ANY);
-                    if (ret < 0) {
-                        Logger::warning("Exact seek to keyframe failed, retrying with backward seek: %s",
-                                       av_error_string(ret).c_str());
-                        ret = av_seek_frame(inputCtx, -1, keyframeSeekTarget, AVSEEK_FLAG_BACKWARD);
+                double packetTime = 0.0;
+                if (!packetTimeSeconds(searchPacket, inputCtx->streams[videoStreamIndex],
+                                       &packetTime)) {
+                    av_packet_unref(searchPacket);
+                    continue;
+                }
+
+                if ((searchPacket->flags & AV_PKT_FLAG_KEY) && packetTime <= startTime) {
+                    cutTime = packetTime;
+                    foundKeyframe = true;
+
+                    // A backward seek already lands on the closest keyframe at or
+                    // before the target, so there is nothing better further on.
+                    if (seekSucceeded) {
+                        av_packet_unref(searchPacket);
+                        break;
                     }
-                    Logger::info("Found keyframe at %.2f seconds (requested %.2f); all streams start here",
-                                effectiveStartTime, startTime);
-                } else {
-                    Logger::warning("No keyframe found before startTime, seeking to original position");
-                    ret = av_seek_frame(inputCtx, -1, static_cast<int64_t>(startTime * AV_TIME_BASE), AVSEEK_FLAG_BACKWARD);
+                }
+
+                if (packetTime > startTime) {
+                    av_packet_unref(searchPacket);
+                    break;
+                }
+
+                av_packet_unref(searchPacket);
+            }
+            av_packet_free(&searchPacket);
+
+            if (foundKeyframe) {
+                double drift = startTime - cutTime;
+                Logger::info("Cutting at keyframe %.2f seconds (requested %.2f, drift %.2f)",
+                             cutTime, startTime, drift);
+                if (drift > Config::TRIM_KEYFRAME_TOLERANCE_SECONDS) {
+                    Logger::warning(
+                        "Keyframe is %.2f seconds before the requested cut; the clip will be "
+                        "that much longer than asked. Lower the encoder keyframe interval to "
+                        "tighten this.",
+                        drift);
+                }
+            } else {
+                Logger::warning("No keyframe found at or before %.2f seconds; "
+                                "cutting at the requested time instead", startTime);
+            }
+
+            // Rewind so the packets consumed by the search get copied. If seeking is
+            // unavailable the scan has already run past the cut point, so fall back
+            // to rewinding to the head of the file and letting the copy loop skip.
+            ret = seekToStart();
+            if (ret < 0) {
+                Logger::warning("Could not rewind to the cut point (%s); restarting from "
+                                "the beginning of the file",
+                                av_error_string(ret).c_str());
+                ret = av_seek_frame(inputCtx, -1, 0, AVSEEK_FLAG_BACKWARD);
+                if (ret < 0) {
+                    Logger::error("Could not rewind the input at all: %s",
+                                  av_error_string(ret).c_str());
+                    avformat_close_input(&inputCtx);
+                    closeOutput(&outputCtx);
+                    return failure(result, "rewind-failed", av_error_string(ret));
                 }
             }
         }
-        
-        // Copy packets from keyframe to end
+
+        result.cutAt = cutTime;
+
+        // Copy packets from the cut point to the end
         {
             AVPacket* packet = av_packet_alloc();
             if (!packet) {
                 Logger::error("Could not allocate packet");
-                goto cleanup;
+                avformat_close_input(&inputCtx);
+                closeOutput(&outputCtx);
+                return failure(result, "packet-alloc-failed");
             }
-            
-            std::vector<int64_t> firstPtsPerStream(inputCtx->nb_streams, AV_NOPTS_VALUE);
-            
+
+            // Every stream is rebased by the same wall-clock offset so they stay in
+            // sync. Filtering on DTS guarantees the shifted timestamps stay positive,
+            // because DTS <= PTS holds for every valid packet.
+            std::vector<bool> streamStarted(inputCtx->nb_streams, false);
+            std::vector<int64_t> lastDts(inputCtx->nb_streams, AV_NOPTS_VALUE);
+
             while (av_read_frame(inputCtx, packet) >= 0) {
                 AVStream* inputStream = inputCtx->streams[packet->stream_index];
                 AVStream* outputStream = outputCtx->streams[packet->stream_index];
-                
-                // Convert packet timestamp to seconds for comparison
+                const int streamIndex = packet->stream_index;
+
                 double packetTime = 0.0;
-                if (packet->pts != AV_NOPTS_VALUE) {
-                    packetTime = static_cast<double>(packet->pts) * av_q2d(inputStream->time_base);
-                } else if (packet->dts != AV_NOPTS_VALUE) {
-                    packetTime = static_cast<double>(packet->dts) * av_q2d(inputStream->time_base);
-                }
-                
-                // Skip packets before the effective start time (all streams use same start)
-                if (packetTime < effectiveStartTime) {
+                if (packetTimeSeconds(packet, inputStream, &packetTime)) {
+                    if (packetTime < cutTime) {
+                        av_packet_unref(packet);
+                        continue;
+                    }
+                } else if (!streamStarted[streamIndex]) {
+                    // No timestamp and nothing copied for this stream yet, so there is
+                    // no way to tell whether it belongs in the clip. Dropping it once
+                    // the stream has started would punch a hole in the output.
                     av_packet_unref(packet);
                     continue;
                 }
-                
-                // Record the first packet timestamp for offset calculation (per stream)
-                int streamIndex = packet->stream_index;
-                int64_t& streamFirstPts = firstPtsPerStream[streamIndex];
-                if (streamFirstPts == AV_NOPTS_VALUE) {
-                    if (packet->pts != AV_NOPTS_VALUE) {
-                        streamFirstPts = av_rescale_q(packet->pts, inputStream->time_base, outputStream->time_base);
-                    } else if (packet->dts != AV_NOPTS_VALUE) {
-                        streamFirstPts = av_rescale_q(packet->dts, inputStream->time_base, outputStream->time_base);
-                    }
 
-                    if (streamFirstPts != AV_NOPTS_VALUE) {
-                        double offsetSeconds = static_cast<double>(streamFirstPts) *
-                                               av_q2d(outputStream->time_base);
-                        Logger::info("Stream %d offset initialized to %.3f seconds", streamIndex, offsetSeconds);
-                    }
-                }
-                
-                // Rescale timestamps
+                streamStarted[streamIndex] = true;
+
+                const int64_t offset = av_rescale_q(static_cast<int64_t>(cutTime * AV_TIME_BASE),
+                                                    AV_TIME_BASE_Q, inputStream->time_base);
+
                 if (packet->pts != AV_NOPTS_VALUE) {
-                    packet->pts = av_rescale_q(packet->pts, inputStream->time_base, outputStream->time_base);
-                    if (streamFirstPts != AV_NOPTS_VALUE) {
-                        packet->pts -= streamFirstPts;
-                    }
+                    packet->pts = av_rescale_q(packet->pts - offset,
+                                               inputStream->time_base, outputStream->time_base);
                 }
-                
                 if (packet->dts != AV_NOPTS_VALUE) {
-                    packet->dts = av_rescale_q(packet->dts, inputStream->time_base, outputStream->time_base);
-                    if (streamFirstPts != AV_NOPTS_VALUE) {
-                        packet->dts -= streamFirstPts;
-                    }
+                    packet->dts = av_rescale_q(packet->dts - offset,
+                                               inputStream->time_base, outputStream->time_base);
                 }
-                
                 if (packet->duration > 0) {
-                    packet->duration = av_rescale_q(packet->duration, inputStream->time_base, outputStream->time_base);
+                    packet->duration = av_rescale_q(packet->duration,
+                                                    inputStream->time_base, outputStream->time_base);
                 }
-                
+
+                // A packet missing only one of the two timestamps is left alone: the
+                // muxer infers the rest, and substituting PTS for a missing DTS
+                // reorders B-frames badly enough that the write fails outright.
+                // A packet missing both carries no ordering information at all, so
+                // step it on from the previous one rather than dropping the frame.
+                if (packet->pts == AV_NOPTS_VALUE && packet->dts == AV_NOPTS_VALUE &&
+                    lastDts[streamIndex] != AV_NOPTS_VALUE) {
+                    packet->dts = lastDts[streamIndex] + (packet->duration > 0 ? packet->duration : 1);
+                    packet->pts = packet->dts;
+                }
+
+                if (packet->dts != AV_NOPTS_VALUE) {
+                    lastDts[streamIndex] = packet->dts;
+                }
+
                 packet->pos = -1;
-                
-                // Write packet
+
                 ret = av_interleaved_write_frame(outputCtx, packet);
                 if (ret < 0) {
                     Logger::error("Error writing packet: %s", av_error_string(ret).c_str());
                     av_packet_free(&packet);
-                    goto cleanup;
+                    avformat_close_input(&inputCtx);
+                    closeOutput(&outputCtx);
+                    return failure(result, "write-packet-failed", av_error_string(ret));
                 }
-                
+
+                result.packetsWritten++;
                 av_packet_unref(packet);
             }
-            
+
             av_packet_free(&packet);
         }
-        
+
+        if (result.packetsWritten == 0) {
+            // Writing a trailer here would produce a valid but empty file, and the
+            // caller would then delete a perfectly good original in exchange for it.
+            Logger::error("No packets were copied; refusing to write an empty clip");
+            avformat_close_input(&inputCtx);
+            closeOutput(&outputCtx);
+            return failure(result, "no-packets-written");
+        }
+
         // Write trailer
         ret = av_write_trailer(outputCtx);
         if (ret < 0) {
             Logger::error("Error writing trailer: %s", av_error_string(ret).c_str());
-            goto cleanup;
+            avformat_close_input(&inputCtx);
+            closeOutput(&outputCtx);
+            return failure(result, "write-trailer-failed", av_error_string(ret));
         }
-        
-        // Cleanup
+
         avformat_close_input(&inputCtx);
-        if (outputCtx && !(outputCtx->oformat->flags & AVFMT_NOFILE)) {
-            avio_closep(&outputCtx->pb);
-        }
-        avformat_free_context(outputCtx);
-        
-        Logger::info("Successfully trimmed video to last %d seconds using libavformat", durationSeconds);
-        return true;
-        
-    cleanup:
+        closeOutput(&outputCtx);
+
+        Logger::info("Copied %lld packets covering %.2f seconds",
+                     static_cast<long long>(result.packetsWritten), totalDuration - cutTime);
+
+        result.success = true;
+        return result;
+
+    } catch (const std::exception& e) {
+        Logger::error("Exception in video trimming: %s", e.what());
         if (inputCtx) {
             avformat_close_input(&inputCtx);
         }
-        if (outputCtx) {
-            if (outputCtx->pb && !(outputCtx->oformat->flags & AVFMT_NOFILE)) {
-                avio_closep(&outputCtx->pb);
-            }
-            avformat_free_context(outputCtx);
-        }
-        return false;
-        
-    } catch (const std::exception& e) {
-        Logger::error("Exception in video trimming: %s", e.what());
-        return false;
+        closeOutput(&outputCtx);
+        return failure(result, "exception", e.what());
     }
 }
 
@@ -330,14 +469,14 @@ double VideoTrimmer::getVideoDuration(const std::string& inputPath, AVFormatCont
     // (though this is unlikely to help since we already tried this inline)
     AVFormatContext* ctx = inputCtx;
     bool shouldClose = false;
-    
+
     if (!ctx) {
         int ret = avformat_open_input(&ctx, inputPath.c_str(), nullptr, nullptr);
         if (ret < 0) {
             Logger::error("Could not open file for duration check: %s", av_error_string(ret).c_str());
             return -1.0;
         }
-        
+
         ret = avformat_find_stream_info(ctx, nullptr);
         if (ret < 0) {
             Logger::error("Could not find stream info for duration check: %s", av_error_string(ret).c_str());
@@ -346,7 +485,7 @@ double VideoTrimmer::getVideoDuration(const std::string& inputPath, AVFormatCont
         }
         shouldClose = true;
     }
-    
+
     double duration = 0.0;
     if (ctx->duration != AV_NOPTS_VALUE) {
         duration = static_cast<double>(ctx->duration) / AV_TIME_BASE;
@@ -360,7 +499,7 @@ double VideoTrimmer::getVideoDuration(const std::string& inputPath, AVFormatCont
             }
         }
     }
-    
+
     if (shouldClose) {
         avformat_close_input(&ctx);
     }
@@ -373,34 +512,34 @@ bool VideoTrimmer::setupOutputStreams(AVFormatContext* inputCtx,
     for (unsigned int i = 0; i < inputCtx->nb_streams; i++) {
         AVStream* inputStream = inputCtx->streams[i];
         AVStream* outputStream = avformat_new_stream(outputCtx, nullptr);
-        
+
         if (!outputStream) {
             Logger::error("Failed to allocate output stream %d", i);
             return false;
         }
-        
+
         // Copy codec parameters
         int ret = avcodec_parameters_copy(outputStream->codecpar, inputStream->codecpar);
         if (ret < 0) {
             Logger::error("Failed to copy codec parameters for stream %d: %s", i, av_error_string(ret).c_str());
             return false;
         }
-        
+
         // Clear codec tag to avoid issues with different containers
         outputStream->codecpar->codec_tag = 0;
-        
+
         // Copy time base
         outputStream->time_base = inputStream->time_base;
 
         // Preserve stream metadata and disposition flags
         av_dict_copy(&outputStream->metadata, inputStream->metadata, 0);
         outputStream->disposition = inputStream->disposition;
-        
-        Logger::info("Setup output stream %d: codec=%s, time_base=%d/%d", 
+
+        Logger::info("Setup output stream %d: codec=%s, time_base=%d/%d",
                     i, avcodec_get_name(outputStream->codecpar->codec_id),
                     outputStream->time_base.num, outputStream->time_base.den);
     }
-    
+
     return true;
 }
 

--- a/src/utils/video-trimmer.cpp
+++ b/src/utils/video-trimmer.cpp
@@ -143,25 +143,8 @@ TrimResult VideoTrimmer::trimToLastSeconds(const std::string& inputPath,
             return failure(result, "stream-info-failed", av_error_string(ret));
         }
 
-        // Get total duration (prefer input context if available)
-        double totalDuration = -1.0;
-        if (inputCtx->duration != AV_NOPTS_VALUE) {
-            totalDuration = static_cast<double>(inputCtx->duration) / AV_TIME_BASE;
-        } else {
-            // Try to get duration from the longest stream
-            for (unsigned int i = 0; i < inputCtx->nb_streams; i++) {
-                AVStream* stream = inputCtx->streams[i];
-                if (stream->duration != AV_NOPTS_VALUE) {
-                    double streamDuration = static_cast<double>(stream->duration) * av_q2d(stream->time_base);
-                    totalDuration = std::max(totalDuration, streamDuration);
-                }
-            }
-        }
-
-        if (totalDuration <= 0) {
-            Logger::warning("Input context duration unavailable, falling back to duration probe");
-            totalDuration = getVideoDuration(inputPath, inputCtx);
-        }
+        // Get total duration
+        double totalDuration = getVideoDuration(inputPath, inputCtx);
         if (totalDuration <= 0) {
             Logger::error("Could not determine video duration or file is empty");
             avformat_close_input(&inputCtx);
@@ -465,8 +448,8 @@ void VideoTrimmer::initializeFFmpeg() {
 }
 
 double VideoTrimmer::getVideoDuration(const std::string& inputPath, AVFormatContext* inputCtx) {
-    // If context is provided, try to extract duration from it first
-    // (though this is unlikely to help since we already tried this inline)
+    // If a context is already open, read duration from it directly instead of
+    // reopening the file
     AVFormatContext* ctx = inputCtx;
     bool shouldClose = false;
 

--- a/src/utils/video-trimmer.hpp
+++ b/src/utils/video-trimmer.hpp
@@ -22,8 +22,24 @@ extern "C" {
 namespace ReplayBufferPro {
 
 /**
+ * @brief Outcome of a trim attempt, including the numbers needed to diagnose it
+ *
+ * On failure, reason is a short stable token suitable for grepping out of an
+ * OBS log; detail carries the underlying libav error text when there is one.
+ */
+struct TrimResult {
+    bool success = false;
+    std::string reason;         ///< Short failure token, empty on success
+    std::string detail;         ///< Human-readable failure detail, may be empty
+    double sourceDuration = 0.0;///< Duration of the input in seconds
+    double requestedStart = 0.0;///< Where the cut was asked for, in seconds
+    double cutAt = 0.0;         ///< Where the keyframe actually put it, in seconds
+    int64_t packetsWritten = 0; ///< Packets copied to the output
+};
+
+/**
  * @brief Video trimming utility class using libavformat
- * 
+ *
  * This class provides static methods for trimming video files using FFmpeg's
  * libavformat library.
  */
@@ -31,47 +47,67 @@ class VideoTrimmer {
 public:
     /**
      * @brief Trim video to last N seconds using libavformat
-     * 
+     *
      * This method opens a video file, calculates the start time for the last
      * N seconds, and creates a new trimmed video file using stream copy
      * (no re-encoding) for maximum performance.
-     * 
+     *
+     * The cut lands on the first keyframe at or before the requested start,
+     * so the output can be longer than requested by up to one GOP. It is
+     * never shorter.
+     *
      * @param inputPath Input video file path
-     * @param outputPath Output video file path  
+     * @param outputPath Output video file path
      * @param durationSeconds Duration in seconds to keep from the end
-     * @return true if successful, false otherwise
+     * @return Outcome of the attempt, including diagnostic timings
      */
-    static bool trimToLastSeconds(const std::string& inputPath, 
-                                 const std::string& outputPath,
-                                 int durationSeconds);
+    static TrimResult trimToLastSeconds(const std::string& inputPath,
+                                        const std::string& outputPath,
+                                        int durationSeconds);
 
-private:
-    /**
-     * @brief Initialize FFmpeg libraries (call once)
-     * 
-     * Initializes the FFmpeg library system. This is called automatically
-     * by trimToLastSeconds but can be called explicitly if needed.
-     */
-    static void initializeFFmpeg();
-    
     /**
      * @brief Get duration of video file in seconds
-     * 
-     * Determines the total duration in seconds. If a context is provided,
-     * attempts to extract duration from it first. Otherwise, opens the file.
-     * 
+     *
+     * Used both internally and by callers verifying that a freshly written
+     * trim is the length it should be.
+     *
      * @param inputPath Path to the video file
      * @param inputCtx Optional already-open format context (may be nullptr)
      * @return Duration in seconds, or -1.0 if error
      */
     static double getVideoDuration(const std::string& inputPath, AVFormatContext* inputCtx = nullptr);
-    
+
+private:
+    /**
+     * @brief Initialize FFmpeg libraries (call once)
+     *
+     * Initializes the FFmpeg library system. This is called automatically
+     * by trimToLastSeconds but can be called explicitly if needed.
+     */
+    static void initializeFFmpeg();
+
+    /**
+     * @brief Open an input file, retrying while it is briefly locked
+     *
+     * OBS kicks off AutoRemux on the same file as it fires the saved event,
+     * and antivirus or cloud-sync clients hold new files open too, so the
+     * first open can lose a race that a retry moments later wins.
+     *
+     * @param inputPath Path to open
+     * @param inputCtx Receives the opened context
+     * @param lastError Receives the final libav error code on failure
+     * @return true if the file was opened
+     */
+    static bool openInputWithRetry(const std::string& inputPath,
+                                   AVFormatContext** inputCtx,
+                                   int* lastError);
+
     /**
      * @brief Setup output streams to match input streams
-     * 
+     *
      * Creates output streams that match the input streams, copying
      * codec parameters for stream copy operation.
-     * 
+     *
      * @param inputCtx Input format context
      * @param outputCtx Output format context
      * @return true if successful, false otherwise


### PR DESCRIPTION
Addresses untrimmed clips from #25

## Problem

Saved clips were intermittently landing at full buffer length instead of trimmed. Every failure path in the old code swallowed its exception, left the untrimmed original in place, and logged at most one generic line — some paths logged nothing at all — which is why the bug was unreproducible and unmeasurable from the reports alone.

## What changed

- Correlate saves through an expiring request queue instead of a single atomic slot, so overlapping saves and dropped requests can't apply the wrong duration or skip trimming entirely.
- Fix the trimmer's keyframe cut-point search, which compared timestamps in the wrong order and could collapse a trim to the full buffer length while still logging success.
- Commit trims through a verified temp file instead of trusting the write blindly — a collapsed or empty trim is rejected and the original kept.
- Retry input open and original delete, since OBS's AutoRemux, antivirus, and cloud-sync clients can all briefly hold the saved file.
- Run trims on a worker thread owned by the manager instead of a detached thread that could outlive it.
- Log one `TRIM VERDICT` line per replay save naming the outcome and cause, and surface success/failure briefly in the OBS status bar.

## Scope

Trimming saves the plugin didn't initiate (OBS's native Save Replay hotkey, the tray item, obs-websocket) is deliberately out of scope for this change — those still save untrimmed by design, now visible as `TRIM VERDICT: skipped reason=no-pending-request` instead of silent. See the log-grep workflow in the docs before deciding whether to build a "trim all replay saves" opt-in.

## Verification

Rebuilt against the current `develop` (branch merged, no conflicts) and confirmed with a standalone harness compiling the real trimmer against FFmpeg over generated files: short GOP, long GOP with B-frames, audio+video, a request exceeding the source, and a single-keyframe file reproducing the collapse. All outputs land in range and decode cleanly; the collapse case is correctly rejected.

Docs updated: `README.md`, `AGENTS.md`, `reference/architecture/replay-buffer-flow.md`, `reference/architecture/utilities.md`, `docs/index.html`, `docs/llms.txt`.